### PR TITLE
simple version propagation from makefile to source code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,15 +5,22 @@ CXXFLAGS= -std=c++11
 
 LDFLAGS= -lz -lm
 
+.PHONY: all clean
+
 cppsrc = $(wildcard src/*.cpp) src/tabix_util/tabix.cpp
 csrc = src/tabix_util/index.c src/tabix_util/bgzf.c
 
+all: version
+
 objs = $(cppsrc:.cpp=.o) $(csrc:.c=.o)
+
+version:
+	@echo "Building version $(VERSION)"
+	@echo "#define VERSION $(VERSION)" > src/version.hpp
+	@$(MAKE) --no-print-directory bin/emeraLD
 
 bin/emeraLD: $(objs)
 	$(CXX) $(CPPFLAGS) -o $@ $^ $(LDFLAGS)
-
-.PHONY: clean
 
 clean: 
 	rm -f src/*.o src/*/*.o bin/emeraLD

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,3 +1,4 @@
+#include "version.hpp"
 #include "processGenotypes.hpp"
 #include "calcLD.hpp"
 #include <stdlib.h>
@@ -42,7 +43,7 @@ void print_usage() {
 int main (int argc, char *argv[]){
 	//cout.precision(5);
 	
-	cerr << "emeraLD v0.1 (c) 2018 corbin quick (corbinq@gmail.com)\n";
+	cerr << "emeraLD v" << VERSION << " (c) 2018 corbin quick (corbinq@gmail.com)\n";
 	
 	string infile = "";
 	string outfile = "";


### PR DESCRIPTION
Implemented naive way to propagate tool version to source code.
You can automatically set VERSION variable in Makefile using git (e.g. based git describe --tags or something like that)