### PR TITLE
Fix compilation issues on MacOS & Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 VERSION=0.1
 
-CPPFLAGS= -Ofast -flto -pipe
+CPPFLAGS= -Ofast -flto -pipe -Isrc
 CXXFLAGS= -std=c++11
 
 LDFLAGS= -lz -lm

--- a/src/boost/assert.hpp
+++ b/src/boost/assert.hpp
@@ -1,0 +1,85 @@
+//
+//  boost/assert.hpp - BOOST_ASSERT(expr)
+//                     BOOST_ASSERT_MSG(expr, msg)
+//                     BOOST_VERIFY(expr)
+//                     BOOST_VERIFY_MSG(expr, msg)
+//                     BOOST_ASSERT_IS_VOID
+//
+//  Copyright (c) 2001, 2002 Peter Dimov and Multi Media Ltd.
+//  Copyright (c) 2007, 2014 Peter Dimov
+//  Copyright (c) Beman Dawes 2011
+//  Copyright (c) 2015 Ion Gaztanaga
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  Note: There are no include guards. This is intentional.
+//
+//  See http://www.boost.org/libs/assert/assert.html for documentation.
+//
+
+//
+// Stop inspect complaining about use of 'assert':
+//
+// boostinspect:naassert_macro
+//
+
+//
+// BOOST_ASSERT, BOOST_ASSERT_MSG, BOOST_ASSERT_IS_VOID
+//
+
+#undef BOOST_ASSERT
+#undef BOOST_ASSERT_MSG
+#undef BOOST_ASSERT_IS_VOID
+
+#if defined(BOOST_DISABLE_ASSERTS) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && defined(NDEBUG) )
+
+# define BOOST_ASSERT(expr) ((void)0)
+# define BOOST_ASSERT_MSG(expr, msg) ((void)0)
+# define BOOST_ASSERT_IS_VOID
+
+#elif defined(BOOST_ENABLE_ASSERT_HANDLER) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) )
+
+#include <boost/config.hpp> // for BOOST_LIKELY
+#include <boost/current_function.hpp>
+
+namespace boost
+{
+    void assertion_failed(char const * expr, char const * function, char const * file, long line); // user defined
+    void assertion_failed_msg(char const * expr, char const * msg, char const * function, char const * file, long line); // user defined
+} // namespace boost
+
+#define BOOST_ASSERT(expr) (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::assertion_failed(#expr, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+#define BOOST_ASSERT_MSG(expr, msg) (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::assertion_failed_msg(#expr, msg, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+
+#else
+
+# include <assert.h> // .h to support old libraries w/o <cassert> - effect is the same
+
+# define BOOST_ASSERT(expr) assert(expr)
+# define BOOST_ASSERT_MSG(expr, msg) assert((expr)&&(msg))
+#if defined(NDEBUG)
+# define BOOST_ASSERT_IS_VOID
+#endif
+
+#endif
+
+//
+// BOOST_VERIFY, BOOST_VERIFY_MSG
+//
+
+#undef BOOST_VERIFY
+#undef BOOST_VERIFY_MSG
+
+#if defined(BOOST_DISABLE_ASSERTS) || ( !defined(BOOST_ENABLE_ASSERT_HANDLER) && defined(NDEBUG) )
+
+# define BOOST_VERIFY(expr) ((void)(expr))
+# define BOOST_VERIFY_MSG(expr, msg) ((void)(expr))
+
+#else
+
+# define BOOST_VERIFY(expr) BOOST_ASSERT(expr)
+# define BOOST_VERIFY_MSG(expr, msg) BOOST_ASSERT_MSG(expr,msg)
+
+#endif

--- a/src/boost/config.hpp
+++ b/src/boost/config.hpp
@@ -1,0 +1,67 @@
+//  Boost config.hpp configuration header file  ------------------------------//
+
+//  (C) Copyright John Maddock 2002.
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/config for most recent version.
+
+//  Boost config.hpp policy and rationale documentation has been moved to
+//  http://www.boost.org/libs/config
+//
+//  CAUTION: This file is intended to be completely stable -
+//           DO NOT MODIFY THIS FILE!
+//
+
+#ifndef BOOST_CONFIG_HPP
+#define BOOST_CONFIG_HPP
+
+// if we don't have a user config, then use the default location:
+#if !defined(BOOST_USER_CONFIG) && !defined(BOOST_NO_USER_CONFIG)
+#  define BOOST_USER_CONFIG <boost/config/user.hpp>
+#if 0
+// For dependency trackers:
+#  include <boost/config/user.hpp>
+#endif
+#endif
+// include it first:
+#ifdef BOOST_USER_CONFIG
+#  include BOOST_USER_CONFIG
+#endif
+
+// if we don't have a compiler config set, try and find one:
+#if !defined(BOOST_COMPILER_CONFIG) && !defined(BOOST_NO_COMPILER_CONFIG) && !defined(BOOST_NO_CONFIG)
+#  include <boost/config/detail/select_compiler_config.hpp>
+#endif
+// if we have a compiler config, include it now:
+#ifdef BOOST_COMPILER_CONFIG
+#  include BOOST_COMPILER_CONFIG
+#endif
+
+// if we don't have a std library config set, try and find one:
+#if !defined(BOOST_STDLIB_CONFIG) && !defined(BOOST_NO_STDLIB_CONFIG) && !defined(BOOST_NO_CONFIG) && defined(__cplusplus)
+#  include <boost/config/detail/select_stdlib_config.hpp>
+#endif
+// if we have a std library config, include it now:
+#ifdef BOOST_STDLIB_CONFIG
+#  include BOOST_STDLIB_CONFIG
+#endif
+
+// if we don't have a platform config set, try and find one:
+#if !defined(BOOST_PLATFORM_CONFIG) && !defined(BOOST_NO_PLATFORM_CONFIG) && !defined(BOOST_NO_CONFIG)
+#  include <boost/config/detail/select_platform_config.hpp>
+#endif
+// if we have a platform config, include it now:
+#ifdef BOOST_PLATFORM_CONFIG
+#  include BOOST_PLATFORM_CONFIG
+#endif
+
+// get config suffix code:
+#include <boost/config/detail/suffix.hpp>
+
+#ifdef BOOST_HAS_PRAGMA_ONCE
+#pragma once
+#endif
+
+#endif  // BOOST_CONFIG_HPP

--- a/src/boost/config/compiler/clang.hpp
+++ b/src/boost/config/compiler/clang.hpp
@@ -1,0 +1,336 @@
+// (C) Copyright Douglas Gregor 2010
+//
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+// Clang compiler setup.
+
+#define BOOST_HAS_PRAGMA_ONCE
+
+// Detecting `-fms-extension` compiler flag assuming that _MSC_VER defined when that flag is used.
+#if defined (_MSC_VER) && (__clang_major__ > 3 || (__clang_major__ == 3 && __clang_minor__ >= 4))
+#   define BOOST_HAS_PRAGMA_DETECT_MISMATCH
+#endif
+
+// When compiling with clang before __has_extension was defined,
+// even if one writes 'defined(__has_extension) && __has_extension(xxx)',
+// clang reports a compiler error. So the only workaround found is:
+
+#ifndef __has_extension
+#define __has_extension __has_feature
+#endif
+
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#ifndef __has_cpp_attribute
+#define __has_cpp_attribute(x) 0
+#endif
+
+#if !__has_feature(cxx_exceptions) && !defined(BOOST_NO_EXCEPTIONS)
+#  define BOOST_NO_EXCEPTIONS
+#endif
+
+#if !__has_feature(cxx_rtti) && !defined(BOOST_NO_RTTI)
+#  define BOOST_NO_RTTI
+#endif
+
+#if !__has_feature(cxx_rtti) && !defined(BOOST_NO_TYPEID)
+#  define BOOST_NO_TYPEID
+#endif
+
+#if !__has_feature(cxx_thread_local)
+#  define BOOST_NO_CXX11_THREAD_LOCAL
+#endif
+
+#ifdef __is_identifier
+#if !__is_identifier(__int64) && !defined(__GNUC__)
+#  define BOOST_HAS_MS_INT64
+#endif
+#endif
+
+#if __has_include(<stdint.h>)
+#  define BOOST_HAS_STDINT_H
+#endif
+
+
+#define BOOST_HAS_NRVO
+
+// Branch prediction hints
+#if !defined (__c2__) && defined(__has_builtin)
+#if __has_builtin(__builtin_expect)
+#define BOOST_LIKELY(x) __builtin_expect(x, 1)
+#define BOOST_UNLIKELY(x) __builtin_expect(x, 0)
+#endif
+#endif
+
+// Clang supports "long long" in all compilation modes.
+#define BOOST_HAS_LONG_LONG
+
+//
+// We disable this if the compiler is really nvcc with C++03 as it
+// doesn't actually support __int128 as of CUDA_VERSION=7500
+// even though it defines __SIZEOF_INT128__.
+// See https://svn.boost.org/trac/boost/ticket/10418
+//     https://svn.boost.org/trac/boost/ticket/11852
+// Only re-enable this for nvcc if you're absolutely sure
+// of the circumstances under which it's supported.
+// Similarly __SIZEOF_INT128__ is defined when targetting msvc
+// compatibility even though the required support functions are absent.
+//
+#if defined(__CUDACC__)
+#  if defined(BOOST_GCC_CXX11)
+#    define BOOST_NVCC_CXX11
+#  else
+#    define BOOST_NVCC_CXX03
+#  endif
+#endif
+
+#if defined(__SIZEOF_INT128__) && !defined(BOOST_NVCC_CXX03) && !defined(_MSC_VER)
+#  define BOOST_HAS_INT128
+#endif
+
+
+//
+// Dynamic shared object (DSO) and dynamic-link library (DLL) support
+//
+#if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__)
+#  define BOOST_HAS_DECLSPEC
+#  define BOOST_SYMBOL_EXPORT __attribute__((__dllexport__))
+#  define BOOST_SYMBOL_IMPORT __attribute__((__dllimport__))
+#else
+#  define BOOST_SYMBOL_EXPORT __attribute__((__visibility__("default")))
+#  define BOOST_SYMBOL_IMPORT
+#endif
+#define BOOST_SYMBOL_VISIBLE __attribute__((__visibility__("default")))
+
+//
+// The BOOST_FALLTHROUGH macro can be used to annotate implicit fall-through
+// between switch labels.
+//
+#if __cplusplus >= 201103L && defined(__has_warning)
+#  if __has_feature(cxx_attributes) && __has_warning("-Wimplicit-fallthrough")
+#    define BOOST_FALLTHROUGH [[clang::fallthrough]]
+#  endif
+#endif
+
+#if !__has_feature(cxx_auto_type)
+#  define BOOST_NO_CXX11_AUTO_DECLARATIONS
+#  define BOOST_NO_CXX11_AUTO_MULTIDECLARATIONS
+#endif
+
+//
+// Currently clang on Windows using VC++ RTL does not support C++11's char16_t or char32_t
+//
+#if (defined(_MSC_VER) && (_MSC_VER < 1900)) || !(defined(__GXX_EXPERIMENTAL_CXX0X__) || __cplusplus >= 201103L)
+#  define BOOST_NO_CXX11_CHAR16_T
+#  define BOOST_NO_CXX11_CHAR32_T
+#endif
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1800) && !defined(__GNUC__)
+#define BOOST_HAS_EXPM1
+#define BOOST_HAS_LOG1P
+#endif
+
+#if !__has_feature(cxx_constexpr)
+#  define BOOST_NO_CXX11_CONSTEXPR
+#endif
+
+#if !__has_feature(cxx_decltype)
+#  define BOOST_NO_CXX11_DECLTYPE
+#endif
+
+#if !__has_feature(cxx_decltype_incomplete_return_types)
+#  define BOOST_NO_CXX11_DECLTYPE_N3276
+#endif
+
+#if !__has_feature(cxx_defaulted_functions)
+#  define BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+#endif
+
+#if !__has_feature(cxx_deleted_functions)
+#  define BOOST_NO_CXX11_DELETED_FUNCTIONS
+#endif
+
+#if !__has_feature(cxx_explicit_conversions)
+#  define BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+#endif
+
+#if !__has_feature(cxx_default_function_template_args)
+#  define BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
+#endif
+
+#if !__has_feature(cxx_generalized_initializers)
+#  define BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#endif
+
+#if !__has_feature(cxx_lambdas)
+#  define BOOST_NO_CXX11_LAMBDAS
+#endif
+
+#if !__has_feature(cxx_local_type_template_args)
+#  define BOOST_NO_CXX11_LOCAL_CLASS_TEMPLATE_PARAMETERS
+#endif
+
+#if !__has_feature(cxx_noexcept)
+#  define BOOST_NO_CXX11_NOEXCEPT
+#endif
+
+#if !__has_feature(cxx_nullptr)
+#  define BOOST_NO_CXX11_NULLPTR
+#endif
+
+#if !__has_feature(cxx_range_for)
+#  define BOOST_NO_CXX11_RANGE_BASED_FOR
+#endif
+
+#if !__has_feature(cxx_raw_string_literals)
+#  define BOOST_NO_CXX11_RAW_LITERALS
+#endif
+
+#if !__has_feature(cxx_reference_qualified_functions)
+#  define BOOST_NO_CXX11_REF_QUALIFIERS
+#endif
+
+#if !__has_feature(cxx_generalized_initializers)
+#  define BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+#endif
+
+#if !__has_feature(cxx_rvalue_references)
+#  define BOOST_NO_CXX11_RVALUE_REFERENCES
+#endif
+
+#if !__has_feature(cxx_strong_enums)
+#  define BOOST_NO_CXX11_SCOPED_ENUMS
+#endif
+
+#if !__has_feature(cxx_static_assert)
+#  define BOOST_NO_CXX11_STATIC_ASSERT
+#endif
+
+#if !__has_feature(cxx_alias_templates)
+#  define BOOST_NO_CXX11_TEMPLATE_ALIASES
+#endif
+
+#if !__has_feature(cxx_unicode_literals)
+#  define BOOST_NO_CXX11_UNICODE_LITERALS
+#endif
+
+#if !__has_feature(cxx_variadic_templates)
+#  define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+
+#if !__has_feature(cxx_user_literals)
+#  define BOOST_NO_CXX11_USER_DEFINED_LITERALS
+#endif
+
+#if !__has_feature(cxx_alignas)
+#  define BOOST_NO_CXX11_ALIGNAS
+#endif
+
+#if !__has_feature(cxx_trailing_return)
+#  define BOOST_NO_CXX11_TRAILING_RESULT_TYPES
+#endif
+
+#if !__has_feature(cxx_inline_namespaces)
+#  define BOOST_NO_CXX11_INLINE_NAMESPACES
+#endif
+
+#if !__has_feature(cxx_override_control)
+#  define BOOST_NO_CXX11_FINAL
+#endif
+
+#if !(__has_feature(__cxx_binary_literals__) || __has_extension(__cxx_binary_literals__))
+#  define BOOST_NO_CXX14_BINARY_LITERALS
+#endif
+
+#if !__has_feature(__cxx_decltype_auto__)
+#  define BOOST_NO_CXX14_DECLTYPE_AUTO
+#endif
+
+#if !__has_feature(__cxx_aggregate_nsdmi__)
+#  define BOOST_NO_CXX14_AGGREGATE_NSDMI
+#endif
+
+#if !__has_feature(__cxx_init_captures__)
+#  define BOOST_NO_CXX14_INITIALIZED_LAMBDA_CAPTURES
+#endif
+
+#if !__has_feature(__cxx_generic_lambdas__)
+#  define BOOST_NO_CXX14_GENERIC_LAMBDAS
+#endif
+
+// clang < 3.5 has a defect with dependent type, like following.
+//
+//  template <class T>
+//  constexpr typename enable_if<pred<T> >::type foo(T &)
+//  { } // error: no return statement in constexpr function
+//
+// This issue also affects C++11 mode, but C++11 constexpr requires return stmt.
+// Therefore we don't care such case.
+//
+// Note that we can't check Clang version directly as the numbering system changes depending who's
+// creating the Clang release (see https://github.com/boostorg/config/pull/39#issuecomment-59927873)
+// so instead verify that we have a feature that was introduced at the same time as working C++14
+// constexpr (generic lambda's in this case):
+//
+#if !__has_feature(__cxx_generic_lambdas__) || !__has_feature(__cxx_relaxed_constexpr__)
+#  define BOOST_NO_CXX14_CONSTEXPR
+#endif
+
+#if !__has_feature(__cxx_return_type_deduction__)
+#  define BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#endif
+
+#if !__has_feature(__cxx_variable_templates__)
+#  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
+#endif
+
+#if !defined(__cpp_structured_bindings) || (__cpp_structured_bindings < 201606)
+#  define BOOST_NO_CXX17_STRUCTURED_BINDINGS
+#endif
+
+// Clang 3.9+ in c++1z
+#if !__has_cpp_attribute(fallthrough) || __cplusplus < 201406L
+#  define BOOST_NO_CXX17_INLINE_VARIABLES
+#  define BOOST_NO_CXX17_FOLD_EXPRESSIONS
+#endif
+
+#if __cplusplus < 201103L
+#define BOOST_NO_CXX11_SFINAE_EXPR
+#endif
+
+#if __cplusplus < 201400
+// All versions with __cplusplus above this value seem to support this:
+#  define BOOST_NO_CXX14_DIGIT_SEPARATORS
+#endif
+//
+// __builtin_unreachable:
+#if defined(__has_builtin) && __has_builtin(__builtin_unreachable)
+#define BOOST_UNREACHABLE_RETURN(x) __builtin_unreachable();
+#endif
+
+#if (__clang_major__ == 3) && (__clang_minor__ == 0)
+// Apparently a clang bug:
+#  define BOOST_NO_CXX11_FIXED_LENGTH_VARIADIC_TEMPLATE_EXPANSION_PACKS
+#endif
+
+// Clang has supported the 'unused' attribute since the first release.
+#define BOOST_ATTRIBUTE_UNUSED __attribute__((__unused__))
+
+// Type aliasing hint.
+#if __has_attribute(__may_alias__)
+#  define BOOST_MAY_ALIAS __attribute__((__may_alias__))
+#endif
+
+#ifndef BOOST_COMPILER
+#  define BOOST_COMPILER "Clang version " __clang_version__
+#endif
+
+// Macro used to identify the Clang compiler.
+#define BOOST_CLANG 1
+

--- a/src/boost/config/compiler/gcc.hpp
+++ b/src/boost/config/compiler/gcc.hpp
@@ -1,0 +1,356 @@
+//  (C) Copyright John Maddock 2001 - 2003.
+//  (C) Copyright Darin Adler 2001 - 2002.
+//  (C) Copyright Jens Maurer 2001 - 2002.
+//  (C) Copyright Beman Dawes 2001 - 2003.
+//  (C) Copyright Douglas Gregor 2002.
+//  (C) Copyright David Abrahams 2002 - 2003.
+//  (C) Copyright Synge Todo 2003.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+//  GNU C++ compiler setup.
+
+//
+// Define BOOST_GCC so we know this is "real" GCC and not some pretender:
+//
+#define BOOST_GCC_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#if !defined(__CUDACC__)
+#define BOOST_GCC BOOST_GCC_VERSION
+#endif
+
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103L)
+#  define BOOST_GCC_CXX11
+#endif
+
+#if __GNUC__ == 3
+#  if defined (__PATHSCALE__)
+#     define BOOST_NO_TWO_PHASE_NAME_LOOKUP
+#     define BOOST_NO_IS_ABSTRACT
+#  endif
+
+#  if __GNUC_MINOR__ < 4
+#     define BOOST_NO_IS_ABSTRACT
+#  endif
+#  define BOOST_NO_CXX11_EXTERN_TEMPLATE
+#endif
+#if __GNUC__ < 4
+//
+// All problems to gcc-3.x and earlier here:
+//
+#define BOOST_NO_TWO_PHASE_NAME_LOOKUP
+#  ifdef __OPEN64__
+#     define BOOST_NO_IS_ABSTRACT
+#  endif
+#endif
+
+// GCC prior to 3.4 had #pragma once too but it didn't work well with filesystem links
+#if BOOST_GCC_VERSION >= 30400
+#define BOOST_HAS_PRAGMA_ONCE
+#endif
+
+#if BOOST_GCC_VERSION < 40400
+// Previous versions of GCC did not completely implement value-initialization:
+// GCC Bug 30111, "Value-initialization of POD base class doesn't initialize
+// members", reported by Jonathan Wakely in 2006,
+// http://gcc.gnu.org/bugzilla/show_bug.cgi?id=30111 (fixed for GCC 4.4)
+// GCC Bug 33916, "Default constructor fails to initialize array members",
+// reported by Michael Elizabeth Chastain in 2007,
+// http://gcc.gnu.org/bugzilla/show_bug.cgi?id=33916 (fixed for GCC 4.2.4)
+// See also: http://www.boost.org/libs/utility/value_init.htm#compiler_issues
+#define BOOST_NO_COMPLETE_VALUE_INITIALIZATION
+#endif
+
+#if !defined(__EXCEPTIONS) && !defined(BOOST_NO_EXCEPTIONS)
+# define BOOST_NO_EXCEPTIONS
+#endif
+
+
+//
+// Threading support: Turn this on unconditionally here (except for
+// those platforms where we can know for sure). It will get turned off again
+// later if no threading API is detected.
+//
+#if !defined(__MINGW32__) && !defined(linux) && !defined(__linux) && !defined(__linux__)
+# define BOOST_HAS_THREADS
+#endif
+
+//
+// gcc has "long long"
+// Except on Darwin with standard compliance enabled (-pedantic)
+// Apple gcc helpfully defines this macro we can query
+//
+#if !defined(__DARWIN_NO_LONG_LONG)
+# define BOOST_HAS_LONG_LONG
+#endif
+
+//
+// gcc implements the named return value optimization since version 3.1
+//
+#define BOOST_HAS_NRVO
+
+// Branch prediction hints
+#define BOOST_LIKELY(x) __builtin_expect(x, 1)
+#define BOOST_UNLIKELY(x) __builtin_expect(x, 0)
+
+//
+// Dynamic shared object (DSO) and dynamic-link library (DLL) support
+//
+#if __GNUC__ >= 4
+#  if defined(_WIN32) || defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__)
+     // All Win32 development environments, including 64-bit Windows and MinGW, define
+     // _WIN32 or one of its variant spellings. Note that Cygwin is a POSIX environment,
+     // so does not define _WIN32 or its variants, but still supports dllexport/dllimport.
+#    define BOOST_HAS_DECLSPEC
+#    define BOOST_SYMBOL_EXPORT __attribute__((__dllexport__))
+#    define BOOST_SYMBOL_IMPORT __attribute__((__dllimport__))
+#  else
+#    define BOOST_SYMBOL_EXPORT __attribute__((__visibility__("default")))
+#    define BOOST_SYMBOL_IMPORT
+#  endif
+#  define BOOST_SYMBOL_VISIBLE __attribute__((__visibility__("default")))
+#else
+// config/platform/win32.hpp will define BOOST_SYMBOL_EXPORT, etc., unless already defined
+#  define BOOST_SYMBOL_EXPORT
+#endif
+
+//
+// RTTI and typeinfo detection is possible post gcc-4.3:
+//
+#if BOOST_GCC_VERSION > 40300
+#  ifndef __GXX_RTTI
+#     ifndef BOOST_NO_TYPEID
+#        define BOOST_NO_TYPEID
+#     endif
+#     ifndef BOOST_NO_RTTI
+#        define BOOST_NO_RTTI
+#     endif
+#  endif
+#endif
+
+//
+// Recent GCC versions have __int128 when in 64-bit mode.
+//
+// We disable this if the compiler is really nvcc with C++03 as it
+// doesn't actually support __int128 as of CUDA_VERSION=7500
+// even though it defines __SIZEOF_INT128__.
+// See https://svn.boost.org/trac/boost/ticket/8048
+//     https://svn.boost.org/trac/boost/ticket/11852
+// Only re-enable this for nvcc if you're absolutely sure
+// of the circumstances under which it's supported:
+//
+#if defined(__CUDACC__)
+#  if defined(BOOST_GCC_CXX11)
+#    define BOOST_NVCC_CXX11
+#  else
+#    define BOOST_NVCC_CXX03
+#  endif
+#endif
+
+#if defined(__SIZEOF_INT128__) && !defined(BOOST_NVCC_CXX03)
+#  define BOOST_HAS_INT128
+#endif
+//
+// Recent GCC versions have a __float128 native type, we need to
+// include a std lib header to detect this - not ideal, but we'll
+// be including <cstddef> later anyway when we select the std lib.
+//
+// Nevertheless, as of CUDA 7.5, using __float128 with the host
+// compiler in pre-C++11 mode is still not supported.
+// See https://svn.boost.org/trac/boost/ticket/11852
+//
+#ifdef __cplusplus
+#include <cstddef>
+#else
+#include <stddef.h>
+#endif
+#if defined(_GLIBCXX_USE_FLOAT128) && !defined(__STRICT_ANSI__) && !defined(BOOST_NVCC_CXX03)
+# define BOOST_HAS_FLOAT128
+#endif
+
+// C++0x features in 4.3.n and later
+//
+#if (BOOST_GCC_VERSION >= 40300) && defined(BOOST_GCC_CXX11)
+// C++0x features are only enabled when -std=c++0x or -std=gnu++0x are
+// passed on the command line, which in turn defines
+// __GXX_EXPERIMENTAL_CXX0X__.
+#  define BOOST_HAS_DECLTYPE
+#  define BOOST_HAS_RVALUE_REFS
+#  define BOOST_HAS_STATIC_ASSERT
+#  define BOOST_HAS_VARIADIC_TMPL
+#else
+#  define BOOST_NO_CXX11_DECLTYPE
+#  define BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS
+#  define BOOST_NO_CXX11_RVALUE_REFERENCES
+#  define BOOST_NO_CXX11_STATIC_ASSERT
+#endif
+
+// C++0x features in 4.4.n and later
+//
+#if (BOOST_GCC_VERSION < 40400) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_AUTO_DECLARATIONS
+#  define BOOST_NO_CXX11_AUTO_MULTIDECLARATIONS
+#  define BOOST_NO_CXX11_CHAR16_T
+#  define BOOST_NO_CXX11_CHAR32_T
+#  define BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#  define BOOST_NO_CXX11_DEFAULTED_FUNCTIONS
+#  define BOOST_NO_CXX11_DELETED_FUNCTIONS
+#  define BOOST_NO_CXX11_TRAILING_RESULT_TYPES
+#  define BOOST_NO_CXX11_INLINE_NAMESPACES
+#  define BOOST_NO_CXX11_VARIADIC_TEMPLATES
+#endif
+
+#if BOOST_GCC_VERSION < 40500
+#  define BOOST_NO_SFINAE_EXPR
+#endif
+
+// GCC 4.5 forbids declaration of defaulted functions in private or protected sections
+#if __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ == 5) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS
+#endif
+
+// C++0x features in 4.5.0 and later
+//
+#if (BOOST_GCC_VERSION < 40500) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS
+#  define BOOST_NO_CXX11_LAMBDAS
+#  define BOOST_NO_CXX11_LOCAL_CLASS_TEMPLATE_PARAMETERS
+#  define BOOST_NO_CXX11_RAW_LITERALS
+#  define BOOST_NO_CXX11_UNICODE_LITERALS
+#endif
+
+// C++0x features in 4.5.1 and later
+//
+#if (BOOST_GCC_VERSION < 40501) || !defined(BOOST_GCC_CXX11)
+// scoped enums have a serious bug in 4.4.0, so define BOOST_NO_CXX11_SCOPED_ENUMS before 4.5.1
+// See http://gcc.gnu.org/bugzilla/show_bug.cgi?id=38064
+#  define BOOST_NO_CXX11_SCOPED_ENUMS
+#endif
+
+// C++0x features in 4.6.n and later
+//
+#if (BOOST_GCC_VERSION < 40600) || !defined(BOOST_GCC_CXX11)
+#define BOOST_NO_CXX11_CONSTEXPR
+#define BOOST_NO_CXX11_DEFAULTED_MOVES
+#define BOOST_NO_CXX11_NOEXCEPT
+#define BOOST_NO_CXX11_NULLPTR
+#define BOOST_NO_CXX11_RANGE_BASED_FOR
+#define BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX
+#endif
+
+// C++0x features in 4.7.n and later
+//
+#if (BOOST_GCC_VERSION < 40700) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_FINAL
+#  define BOOST_NO_CXX11_TEMPLATE_ALIASES
+#  define BOOST_NO_CXX11_USER_DEFINED_LITERALS
+#  define BOOST_NO_CXX11_FIXED_LENGTH_VARIADIC_TEMPLATE_EXPANSION_PACKS
+#endif
+
+// C++0x features in 4.8.n and later
+//
+#if (BOOST_GCC_VERSION < 40800) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_ALIGNAS
+#  define BOOST_NO_CXX11_THREAD_LOCAL
+#  define BOOST_NO_CXX11_SFINAE_EXPR
+#endif
+
+// C++0x features in 4.8.1 and later
+//
+#if (BOOST_GCC_VERSION < 40801) || !defined(BOOST_GCC_CXX11)
+#  define BOOST_NO_CXX11_DECLTYPE_N3276
+#  define BOOST_NO_CXX11_REF_QUALIFIERS
+#  define BOOST_NO_CXX14_BINARY_LITERALS
+#endif
+
+// C++14 features in 4.9.0 and later
+//
+#if (BOOST_GCC_VERSION < 40900) || (__cplusplus < 201300)
+#  define BOOST_NO_CXX14_RETURN_TYPE_DEDUCTION
+#  define BOOST_NO_CXX14_GENERIC_LAMBDAS
+#  define BOOST_NO_CXX14_DIGIT_SEPARATORS
+#  define BOOST_NO_CXX14_DECLTYPE_AUTO
+#  if !((BOOST_GCC_VERSION >= 40801) && (BOOST_GCC_VERSION < 40900) && defined(BOOST_GCC_CXX11))
+#     define BOOST_NO_CXX14_INITIALIZED_LAMBDA_CAPTURES
+#  endif
+#endif
+
+
+// C++ 14:
+#if !defined(__cpp_aggregate_nsdmi) || (__cpp_aggregate_nsdmi < 201304)
+#  define BOOST_NO_CXX14_AGGREGATE_NSDMI
+#endif
+#if !defined(__cpp_constexpr) || (__cpp_constexpr < 201304)
+#  define BOOST_NO_CXX14_CONSTEXPR
+#endif
+#if (BOOST_GCC_VERSION < 50200) || !defined(__cpp_variable_templates) || (__cpp_variable_templates < 201304)
+#  define BOOST_NO_CXX14_VARIABLE_TEMPLATES
+#endif
+
+// C++17
+#if !defined(__cpp_structured_bindings) || (__cpp_structured_bindings < 201606)
+#  define BOOST_NO_CXX17_STRUCTURED_BINDINGS
+#endif
+#if !defined(__cpp_inline_variables) || (__cpp_inline_variables < 201606)
+#  define BOOST_NO_CXX17_INLINE_VARIABLES
+#endif
+#if !defined(__cpp_fold_expressions) || (__cpp_fold_expressions < 201603)
+#  define BOOST_NO_CXX17_FOLD_EXPRESSIONS
+#endif
+
+#if __GNUC__ >= 7
+#  define BOOST_FALLTHROUGH __attribute__((fallthrough))
+#endif
+
+#ifdef __MINGW32__
+// Currently (June 2017) thread_local is broken on mingw for all current compiler releases, see
+// https://sourceforge.net/p/mingw-w64/bugs/527/
+// Not setting this causes program termination on thread exit.
+#define BOOST_NO_CXX11_THREAD_LOCAL
+#endif
+
+//
+// Unused attribute:
+#if __GNUC__ >= 4
+#  define BOOST_ATTRIBUTE_UNUSED __attribute__((__unused__))
+#endif
+
+// Type aliasing hint. Supported since gcc 3.3.
+#define BOOST_MAY_ALIAS __attribute__((__may_alias__))
+
+//
+// __builtin_unreachable:
+#if BOOST_GCC_VERSION >= 40800
+#define BOOST_UNREACHABLE_RETURN(x) __builtin_unreachable();
+#endif
+
+#ifndef BOOST_COMPILER
+#  define BOOST_COMPILER "GNU C++ version " __VERSION__
+#endif
+
+// ConceptGCC compiler:
+//   http://www.generic-programming.org/software/ConceptGCC/
+#ifdef __GXX_CONCEPTS__
+#  define BOOST_HAS_CONCEPTS
+#  define BOOST_COMPILER "ConceptGCC version " __VERSION__
+#endif
+
+// versions check:
+// we don't know gcc prior to version 3.30:
+#if (BOOST_GCC_VERSION< 30300)
+#  error "Compiler not configured - please reconfigure"
+#endif
+//
+// last known and checked version is 7.1:
+#if (BOOST_GCC_VERSION > 70100)
+#  if defined(BOOST_ASSERT_CONFIG)
+#     error "Boost.Config is older than your compiler - please check for an updated Boost release."
+#  else
+// we don't emit warnings here anymore since there are no defect macros defined for
+// gcc post 3.4, so any failures are gcc regressions...
+//#     warning "Unknown compiler version - please run the configure tests and report the results"
+#  endif
+#endif
+

--- a/src/boost/config/detail/posix_features.hpp
+++ b/src/boost/config/detail/posix_features.hpp
@@ -1,0 +1,95 @@
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+//  See http://www.boost.org for most recent version.
+
+// All POSIX feature tests go in this file,
+// Note that we test _POSIX_C_SOURCE and _XOPEN_SOURCE as well
+// _POSIX_VERSION and _XOPEN_VERSION: on some systems POSIX API's
+// may be present but none-functional unless _POSIX_C_SOURCE and
+// _XOPEN_SOURCE have been defined to the right value (it's up
+// to the user to do this *before* including any header, although
+// in most cases the compiler will do this for you).
+
+#  if defined(BOOST_HAS_UNISTD_H)
+#     include <unistd.h>
+
+      // XOpen has <nl_types.h>, but is this the correct version check?
+#     if defined(_XOPEN_VERSION) && (_XOPEN_VERSION >= 3)
+#        define BOOST_HAS_NL_TYPES_H
+#     endif
+
+      // POSIX version 6 requires <stdint.h>
+#     if defined(_POSIX_VERSION) && (_POSIX_VERSION >= 200100)
+#        define BOOST_HAS_STDINT_H
+#     endif
+
+      // POSIX version 2 requires <dirent.h>
+#     if defined(_POSIX_VERSION) && (_POSIX_VERSION >= 199009L)
+#        define BOOST_HAS_DIRENT_H
+#     endif
+
+      // POSIX version 3 requires <signal.h> to have sigaction:
+#     if defined(_POSIX_VERSION) && (_POSIX_VERSION >= 199506L)
+#        define BOOST_HAS_SIGACTION
+#     endif
+      // POSIX defines _POSIX_THREADS > 0 for pthread support,
+      // however some platforms define _POSIX_THREADS without
+      // a value, hence the (_POSIX_THREADS+0 >= 0) check.
+      // Strictly speaking this may catch platforms with a
+      // non-functioning stub <pthreads.h>, but such occurrences should
+      // occur very rarely if at all.
+#     if defined(_POSIX_THREADS) && (_POSIX_THREADS+0 >= 0) && !defined(BOOST_HAS_WINTHREADS) && !defined(BOOST_HAS_MPTASKS)
+#        define BOOST_HAS_PTHREADS
+#     endif
+
+      // BOOST_HAS_NANOSLEEP:
+      // This is predicated on _POSIX_TIMERS or _XOPEN_REALTIME:
+#     if (defined(_POSIX_TIMERS) && (_POSIX_TIMERS+0 >= 0)) \
+             || (defined(_XOPEN_REALTIME) && (_XOPEN_REALTIME+0 >= 0))
+#        define BOOST_HAS_NANOSLEEP
+#     endif
+
+      // BOOST_HAS_CLOCK_GETTIME:
+      // This is predicated on _POSIX_TIMERS (also on _XOPEN_REALTIME
+      // but at least one platform - linux - defines that flag without
+      // defining clock_gettime):
+#     if (defined(_POSIX_TIMERS) && (_POSIX_TIMERS+0 >= 0))
+#        define BOOST_HAS_CLOCK_GETTIME
+#     endif
+
+      // BOOST_HAS_SCHED_YIELD:
+      // This is predicated on _POSIX_PRIORITY_SCHEDULING or
+      // on _POSIX_THREAD_PRIORITY_SCHEDULING or on _XOPEN_REALTIME.
+#     if defined(_POSIX_PRIORITY_SCHEDULING) && (_POSIX_PRIORITY_SCHEDULING+0 > 0)\
+            || (defined(_POSIX_THREAD_PRIORITY_SCHEDULING) && (_POSIX_THREAD_PRIORITY_SCHEDULING+0 > 0))\
+            || (defined(_XOPEN_REALTIME) && (_XOPEN_REALTIME+0 >= 0))
+#        define BOOST_HAS_SCHED_YIELD
+#     endif
+
+      // BOOST_HAS_GETTIMEOFDAY:
+      // BOOST_HAS_PTHREAD_MUTEXATTR_SETTYPE:
+      // These are predicated on _XOPEN_VERSION, and appears to be first released
+      // in issue 4, version 2 (_XOPEN_VERSION > 500).
+      // Likewise for the functions log1p and expm1.
+#     if defined(_XOPEN_VERSION) && (_XOPEN_VERSION+0 >= 500)
+#        define BOOST_HAS_GETTIMEOFDAY
+#        if defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE+0 >= 500)
+#           define BOOST_HAS_PTHREAD_MUTEXATTR_SETTYPE
+#        endif
+#        ifndef BOOST_HAS_LOG1P
+#           define BOOST_HAS_LOG1P
+#        endif
+#        ifndef BOOST_HAS_EXPM1
+#           define BOOST_HAS_EXPM1
+#        endif
+#     endif
+
+#  endif
+
+
+
+

--- a/src/boost/config/detail/select_compiler_config.hpp
+++ b/src/boost/config/detail/select_compiler_config.hpp
@@ -1,0 +1,158 @@
+//  Boost compiler configuration selection header file
+
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  (C) Copyright Martin Wille 2003.
+//  (C) Copyright Guillaume Melquiond 2003.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  (See accompanying file LICENSE_1_0.txt or copy at
+//   http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/ for most recent version.
+
+// locate which compiler we are using and define
+// BOOST_COMPILER_CONFIG as needed: 
+
+#if defined __CUDACC__
+//  NVIDIA CUDA C++ compiler for GPU
+#   include "boost/config/compiler/nvcc.hpp"
+
+#endif
+
+#if defined(__GCCXML__)
+// GCC-XML emulates other compilers, it has to appear first here!
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/gcc_xml.hpp"
+
+#elif defined(_CRAYC)
+// EDG based Cray compiler:
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/cray.hpp"
+
+#elif defined __COMO__
+//  Comeau C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/comeau.hpp"
+
+#elif defined(__PATHSCALE__) && (__PATHCC__ >= 4)
+// PathScale EKOPath compiler (has to come before clang and gcc)
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/pathscale.hpp"
+
+#elif defined(__INTEL_COMPILER) || defined(__ICL) || defined(__ICC) || defined(__ECC)
+//  Intel
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/intel.hpp"
+
+#elif defined __clang__ && !defined(__CUDACC__) && !defined(__ibmxl__)
+// when using clang and cuda at same time, you want to appear as gcc
+//  Clang C++ emulates GCC, so it has to appear early.
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/clang.hpp"
+
+#elif defined __DMC__
+//  Digital Mars C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/digitalmars.hpp"
+
+#elif defined __DCC__
+//  Wind River Diab C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/diab.hpp"
+
+#elif defined(__PGI)
+//  Portland Group Inc.
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/pgi.hpp"
+
+# elif defined(__GNUC__) && !defined(__ibmxl__)
+//  GNU C++:
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/gcc.hpp"
+
+#elif defined __KCC
+//  Kai C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/kai.hpp"
+
+#elif defined __sgi
+//  SGI MIPSpro C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/sgi_mipspro.hpp"
+
+#elif defined __DECCXX
+//  Compaq Tru64 Unix cxx
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/compaq_cxx.hpp"
+
+#elif defined __ghs
+//  Greenhills C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/greenhills.hpp"
+
+#elif defined __CODEGEARC__
+//  CodeGear - must be checked for before Borland
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/codegear.hpp"
+
+#elif defined __BORLANDC__
+//  Borland
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/borland.hpp"
+
+#elif defined  __MWERKS__
+//  Metrowerks CodeWarrior
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/metrowerks.hpp"
+
+#elif defined  __SUNPRO_CC
+//  Sun Workshop Compiler C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/sunpro_cc.hpp"
+
+#elif defined __HP_aCC
+//  HP aCC
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/hp_acc.hpp"
+
+#elif defined(__MRC__) || defined(__SC__)
+//  MPW MrCpp or SCpp
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/mpw.hpp"
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__) && defined(__MVS__)
+//  IBM z/OS XL C/C++
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/xlcpp_zos.hpp"
+
+#elif defined(__ibmxl__)
+//  IBM XL C/C++ for Linux (Little Endian)
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/xlcpp.hpp"
+
+#elif defined(__IBMCPP__)
+//  IBM Visual Age or IBM XL C/C++ for Linux (Big Endian)
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/vacpp.hpp"
+
+#elif defined _MSC_VER
+//  Microsoft Visual C++
+//
+//  Must remain the last #elif since some other vendors (Metrowerks, for
+//  example) also #define _MSC_VER
+#   define BOOST_COMPILER_CONFIG "boost/config/compiler/visualc.hpp"
+
+#elif defined (BOOST_ASSERT_CONFIG)
+// this must come last - generate an error if we don't
+// recognise the compiler:
+#  error "Unknown compiler - please configure (http://www.boost.org/libs/config/config.htm#configuring) and report the results to the main boost mailing list (http://www.boost.org/more/mailing_lists.htm#main)"
+
+#endif
+
+#if 0
+//
+// This section allows dependency scanners to find all the headers we *might* include:
+//
+#include <boost/config/compiler/gcc_xml.hpp>
+#include <boost/config/compiler/cray.hpp>
+#include <boost/config/compiler/comeau.hpp>
+#include <boost/config/compiler/pathscale.hpp>
+#include <boost/config/compiler/intel.hpp>
+#include <boost/config/compiler/clang.hpp>
+#include <boost/config/compiler/digitalmars.hpp>
+#include <boost/config/compiler/gcc.hpp>
+#include <boost/config/compiler/kai.hpp>
+#include <boost/config/compiler/sgi_mipspro.hpp>
+#include <boost/config/compiler/compaq_cxx.hpp>
+#include <boost/config/compiler/greenhills.hpp>
+#include <boost/config/compiler/codegear.hpp>
+#include <boost/config/compiler/borland.hpp>
+#include <boost/config/compiler/metrowerks.hpp>
+#include <boost/config/compiler/sunpro_cc.hpp>
+#include <boost/config/compiler/hp_acc.hpp>
+#include <boost/config/compiler/mpw.hpp>
+#include <boost/config/compiler/xlcpp_zos.hpp>
+#include <boost/config/compiler/xlcpp.hpp>
+#include <boost/config/compiler/vacpp.hpp>
+#include <boost/config/compiler/pgi.hpp>
+#include <boost/config/compiler/visualc.hpp>
+
+#endif
+

--- a/src/boost/config/detail/select_platform_config.hpp
+++ b/src/boost/config/detail/select_platform_config.hpp
@@ -1,0 +1,142 @@
+//  Boost compiler configuration selection header file
+
+//  (C) Copyright John Maddock 2001 - 2002. 
+//  (C) Copyright Jens Maurer 2001. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+// locate which platform we are on and define BOOST_PLATFORM_CONFIG as needed.
+// Note that we define the headers to include using "header_name" not
+// <header_name> in order to prevent macro expansion within the header
+// name (for example "linux" is a macro on linux systems).
+
+#if (defined(linux) || defined(__linux) || defined(__linux__) || defined(__GNU__) || defined(__GLIBC__)) && !defined(_CRAYC)
+// linux, also other platforms (Hurd etc) that use GLIBC, should these really have their own config headers though?
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/linux.hpp"
+
+#elif defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__)
+// BSD:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/bsd.hpp"
+
+#elif defined(sun) || defined(__sun)
+// solaris:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/solaris.hpp"
+
+#elif defined(__sgi)
+// SGI Irix:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/irix.hpp"
+
+#elif defined(__hpux)
+// hp unix:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/hpux.hpp"
+
+#elif defined(__CYGWIN__)
+// cygwin is not win32:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/cygwin.hpp"
+
+#elif defined(_WIN32) || defined(__WIN32__) || defined(WIN32)
+// win32:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/win32.hpp"
+
+#elif defined(__HAIKU__)
+// Haiku
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/haiku.hpp"
+
+#elif defined(__BEOS__)
+// BeOS
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/beos.hpp"
+
+#elif defined(macintosh) || defined(__APPLE__) || defined(__APPLE_CC__)
+// MacOS
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/macos.hpp"
+
+#elif defined(__TOS_MVS__)
+// IBM z/OS
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/zos.hpp"
+
+#elif defined(__IBMCPP__) || defined(_AIX)
+// IBM AIX
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/aix.hpp"
+
+#elif defined(__amigaos__)
+// AmigaOS
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/amigaos.hpp"
+
+#elif defined(__QNXNTO__)
+// QNX:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/qnxnto.hpp"
+
+#elif defined(__VXWORKS__)
+// vxWorks:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/vxworks.hpp"
+
+#elif defined(__SYMBIAN32__) 
+// Symbian: 
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/symbian.hpp" 
+
+#elif defined(_CRAYC)
+// Cray:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/cray.hpp" 
+
+#elif defined(__VMS) 
+// VMS:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/vms.hpp" 
+
+#elif defined(__CloudABI__)
+// Nuxi CloudABI:
+#  define BOOST_PLATFORM_CONFIG "boost/config/platform/cloudabi.hpp"
+#else
+
+#  if defined(unix) \
+      || defined(__unix) \
+      || defined(_XOPEN_SOURCE) \
+      || defined(_POSIX_SOURCE)
+
+   // generic unix platform:
+
+#  ifndef BOOST_HAS_UNISTD_H
+#     define BOOST_HAS_UNISTD_H
+#  endif
+
+#  include <boost/config/detail/posix_features.hpp>
+
+#  endif
+
+#  if defined (BOOST_ASSERT_CONFIG)
+      // this must come last - generate an error if we don't
+      // recognise the platform:
+#     error "Unknown platform - please configure and report the results to boost.org"
+#  endif
+
+#endif
+
+#if 0
+//
+// This section allows dependency scanners to find all the files we *might* include:
+//
+#  include "boost/config/platform/linux.hpp"
+#  include "boost/config/platform/bsd.hpp"
+#  include "boost/config/platform/solaris.hpp"
+#  include "boost/config/platform/irix.hpp"
+#  include "boost/config/platform/hpux.hpp"
+#  include "boost/config/platform/cygwin.hpp"
+#  include "boost/config/platform/win32.hpp"
+#  include "boost/config/platform/beos.hpp"
+#  include "boost/config/platform/macos.hpp"
+#  include "boost/config/platform/zos.hpp"
+#  include "boost/config/platform/aix.hpp"
+#  include "boost/config/platform/amigaos.hpp"
+#  include "boost/config/platform/qnxnto.hpp"
+#  include "boost/config/platform/vxworks.hpp"
+#  include "boost/config/platform/symbian.hpp" 
+#  include "boost/config/platform/cray.hpp" 
+#  include "boost/config/platform/vms.hpp" 
+#  include <boost/config/detail/posix_features.hpp>
+
+
+
+#endif
+

--- a/src/boost/config/detail/select_stdlib_config.hpp
+++ b/src/boost/config/detail/select_stdlib_config.hpp
@@ -1,0 +1,110 @@
+//  Boost compiler configuration selection header file
+
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  (C) Copyright Jens Maurer 2001 - 2002. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+
+//  See http://www.boost.org for most recent version.
+
+// locate which std lib we are using and define BOOST_STDLIB_CONFIG as needed:
+
+// First include <cstddef> to determine if some version of STLport is in use as the std lib
+// (do not rely on this header being included since users can short-circuit this header 
+//  if they know whose std lib they are using.)
+#ifdef __cplusplus
+#  include <cstddef>
+#else
+#  include <stddef.h>
+#endif
+
+#if defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION)
+// STLPort library; this _must_ come first, otherwise since
+// STLport typically sits on top of some other library, we
+// can end up detecting that first rather than STLport:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/stlport.hpp"
+
+#else
+
+// If our std lib was not some version of STLport, and has not otherwise
+// been detected, then include <utility> as it is about 
+// the smallest of the std lib headers that includes real C++ stuff.
+// Some std libs do not include their C++-related macros in <cstddef> 
+// so this additional include makes sure we get those definitions.
+// Note: do not rely on this header being included since users can short-circuit this 
+// #include if they know whose std lib they are using.
+#if !defined(__LIBCOMO__) && !defined(__STD_RWCOMPILER_H__) && !defined(_RWSTD_VER)\
+   && !defined(_LIBCPP_VERSION) && !defined(__GLIBCPP__) && !defined(__GLIBCXX__)\
+   && !defined(__STL_CONFIG_H) && !defined(__MSL_CPP__) && !defined(__IBMCPP__)\
+   && !defined(MSIPL_COMPILE_H) && !defined(_YVALS) && !defined(_CPPLIB_VER)
+#include <utility>
+#endif
+
+#if defined(__LIBCOMO__)
+// Comeau STL:
+#define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcomo.hpp"
+
+#elif defined(__STD_RWCOMPILER_H__) || defined(_RWSTD_VER)
+// Rogue Wave library:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/roguewave.hpp"
+
+#elif defined(_LIBCPP_VERSION)
+// libc++
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libcpp.hpp"
+
+#elif defined(__GLIBCPP__) || defined(__GLIBCXX__)
+// GNU libstdc++ 3
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/libstdcpp3.hpp"
+
+#elif defined(__STL_CONFIG_H)
+// generic SGI STL
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/sgi.hpp"
+
+#elif defined(__MSL_CPP__)
+// MSL standard lib:
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/msl.hpp"
+
+#elif defined(__IBMCPP__) && defined(__COMPILER_VER__) && defined(__MVS__)
+// IBM z/OS XL C/C++
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/xlcpp_zos.hpp"
+
+#elif defined(__IBMCPP__)
+// take the default VACPP std lib
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/vacpp.hpp"
+
+#elif defined(MSIPL_COMPILE_H)
+// Modena C++ standard library
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/modena.hpp"
+
+#elif (defined(_YVALS) && !defined(__IBMCPP__)) || defined(_CPPLIB_VER)
+// Dinkumware Library (this has to appear after any possible replacement libraries):
+#  define BOOST_STDLIB_CONFIG "boost/config/stdlib/dinkumware.hpp"
+
+#elif defined (BOOST_ASSERT_CONFIG)
+// this must come last - generate an error if we don't
+// recognise the library:
+#  error "Unknown standard library - please configure and report the results to boost.org"
+
+#endif
+
+#endif
+
+#if 0
+//
+// This section allows dependency scanners to find all the files we *might* include:
+//
+#  include "boost/config/stdlib/stlport.hpp"
+#  include "boost/config/stdlib/libcomo.hpp"
+#  include "boost/config/stdlib/roguewave.hpp"
+#  include "boost/config/stdlib/libcpp.hpp"
+#  include "boost/config/stdlib/libstdcpp3.hpp"
+#  include "boost/config/stdlib/sgi.hpp"
+#  include "boost/config/stdlib/msl.hpp"
+#  include "boost/config/stdlib/xlcpp_zos.hpp"
+#  include "boost/config/stdlib/vacpp.hpp"
+#  include "boost/config/stdlib/modena.hpp"
+#  include "boost/config/stdlib/dinkumware.hpp"
+#endif
+

--- a/src/boost/config/detail/suffix.hpp
+++ b/src/boost/config/detail/suffix.hpp
@@ -1,0 +1,1036 @@
+//  Boost config.hpp configuration header file  ------------------------------//
+//  boostinspect:ndprecated_macros -- tell the inspect tool to ignore this file
+
+//  Copyright (c) 2001-2003 John Maddock
+//  Copyright (c) 2001 Darin Adler
+//  Copyright (c) 2001 Peter Dimov
+//  Copyright (c) 2002 Bill Kempf
+//  Copyright (c) 2002 Jens Maurer
+//  Copyright (c) 2002-2003 David Abrahams
+//  Copyright (c) 2003 Gennaro Prota
+//  Copyright (c) 2003 Eric Friedman
+//  Copyright (c) 2010 Eric Jourdanneau, Joel Falcou
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/ for most recent version.
+
+//  Boost config.hpp policy and rationale documentation has been moved to
+//  http://www.boost.org/libs/config/
+//
+//  This file is intended to be stable, and relatively unchanging.
+//  It should contain boilerplate code only - no compiler specific
+//  code unless it is unavoidable - no changes unless unavoidable.
+
+#ifndef BOOST_CONFIG_SUFFIX_HPP
+#define BOOST_CONFIG_SUFFIX_HPP
+
+#if defined(__GNUC__) && (__GNUC__ >= 4)
+//
+// Some GCC-4.x versions issue warnings even when __extension__ is used,
+// so use this as a workaround:
+//
+#pragma GCC system_header
+#endif
+
+//
+// ensure that visibility macros are always defined, thus symplifying use
+//
+#ifndef BOOST_SYMBOL_EXPORT
+# define BOOST_SYMBOL_EXPORT
+#endif
+#ifndef BOOST_SYMBOL_IMPORT
+# define BOOST_SYMBOL_IMPORT
+#endif
+#ifndef BOOST_SYMBOL_VISIBLE
+# define BOOST_SYMBOL_VISIBLE
+#endif
+
+//
+// look for long long by looking for the appropriate macros in <limits.h>.
+// Note that we use limits.h rather than climits for maximal portability,
+// remember that since these just declare a bunch of macros, there should be
+// no namespace issues from this.
+//
+#if !defined(BOOST_HAS_LONG_LONG) && !defined(BOOST_NO_LONG_LONG)                                              \
+   && !defined(BOOST_MSVC) && !defined(__BORLANDC__)
+# include <limits.h>
+# if (defined(ULLONG_MAX) || defined(ULONG_LONG_MAX) || defined(ULONGLONG_MAX))
+#   define BOOST_HAS_LONG_LONG
+# else
+#   define BOOST_NO_LONG_LONG
+# endif
+#endif
+
+// GCC 3.x will clean up all of those nasty macro definitions that
+// BOOST_NO_CTYPE_FUNCTIONS is intended to help work around, so undefine
+// it under GCC 3.x.
+#if defined(__GNUC__) && (__GNUC__ >= 3) && defined(BOOST_NO_CTYPE_FUNCTIONS)
+#  undef BOOST_NO_CTYPE_FUNCTIONS
+#endif
+
+//
+// Assume any extensions are in namespace std:: unless stated otherwise:
+//
+#  ifndef BOOST_STD_EXTENSION_NAMESPACE
+#    define BOOST_STD_EXTENSION_NAMESPACE std
+#  endif
+
+//
+// If cv-qualified specializations are not allowed, then neither are cv-void ones:
+//
+#  if defined(BOOST_NO_CV_SPECIALIZATIONS) \
+      && !defined(BOOST_NO_CV_VOID_SPECIALIZATIONS)
+#     define BOOST_NO_CV_VOID_SPECIALIZATIONS
+#  endif
+
+//
+// If there is no numeric_limits template, then it can't have any compile time
+// constants either!
+//
+#  if defined(BOOST_NO_LIMITS) \
+      && !defined(BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS)
+#     define BOOST_NO_LIMITS_COMPILE_TIME_CONSTANTS
+#     define BOOST_NO_MS_INT64_NUMERIC_LIMITS
+#     define BOOST_NO_LONG_LONG_NUMERIC_LIMITS
+#  endif
+
+//
+// if there is no long long then there is no specialisation
+// for numeric_limits<long long> either:
+//
+#if !defined(BOOST_HAS_LONG_LONG) && !defined(BOOST_NO_LONG_LONG_NUMERIC_LIMITS)
+#  define BOOST_NO_LONG_LONG_NUMERIC_LIMITS
+#endif
+
+//
+// if there is no __int64 then there is no specialisation
+// for numeric_limits<__int64> either:
+//
+#if !defined(BOOST_HAS_MS_INT64) && !defined(BOOST_NO_MS_INT64_NUMERIC_LIMITS)
+#  define BOOST_NO_MS_INT64_NUMERIC_LIMITS
+#endif
+
+//
+// if member templates are supported then so is the
+// VC6 subset of member templates:
+//
+#  if !defined(BOOST_NO_MEMBER_TEMPLATES) \
+       && !defined(BOOST_MSVC6_MEMBER_TEMPLATES)
+#     define BOOST_MSVC6_MEMBER_TEMPLATES
+#  endif
+
+//
+// Without partial specialization, can't test for partial specialisation bugs:
+//
+#  if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) \
+      && !defined(BOOST_BCB_PARTIAL_SPECIALIZATION_BUG)
+#     define BOOST_BCB_PARTIAL_SPECIALIZATION_BUG
+#  endif
+
+//
+// Without partial specialization, we can't have array-type partial specialisations:
+//
+#  if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) \
+      && !defined(BOOST_NO_ARRAY_TYPE_SPECIALIZATIONS)
+#     define BOOST_NO_ARRAY_TYPE_SPECIALIZATIONS
+#  endif
+
+//
+// Without partial specialization, std::iterator_traits can't work:
+//
+#  if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) \
+      && !defined(BOOST_NO_STD_ITERATOR_TRAITS)
+#     define BOOST_NO_STD_ITERATOR_TRAITS
+#  endif
+
+//
+// Without partial specialization, partial
+// specialization with default args won't work either:
+//
+#  if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) \
+      && !defined(BOOST_NO_PARTIAL_SPECIALIZATION_IMPLICIT_DEFAULT_ARGS)
+#     define BOOST_NO_PARTIAL_SPECIALIZATION_IMPLICIT_DEFAULT_ARGS
+#  endif
+
+//
+// Without member template support, we can't have template constructors
+// in the standard library either:
+//
+#  if defined(BOOST_NO_MEMBER_TEMPLATES) \
+      && !defined(BOOST_MSVC6_MEMBER_TEMPLATES) \
+      && !defined(BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS)
+#     define BOOST_NO_TEMPLATED_ITERATOR_CONSTRUCTORS
+#  endif
+
+//
+// Without member template support, we can't have a conforming
+// std::allocator template either:
+//
+#  if defined(BOOST_NO_MEMBER_TEMPLATES) \
+      && !defined(BOOST_MSVC6_MEMBER_TEMPLATES) \
+      && !defined(BOOST_NO_STD_ALLOCATOR)
+#     define BOOST_NO_STD_ALLOCATOR
+#  endif
+
+//
+// without ADL support then using declarations will break ADL as well:
+//
+#if defined(BOOST_NO_ARGUMENT_DEPENDENT_LOOKUP) && !defined(BOOST_FUNCTION_SCOPE_USING_DECLARATION_BREAKS_ADL)
+#  define BOOST_FUNCTION_SCOPE_USING_DECLARATION_BREAKS_ADL
+#endif
+
+//
+// Without typeid support we have no dynamic RTTI either:
+//
+#if defined(BOOST_NO_TYPEID) && !defined(BOOST_NO_RTTI)
+#  define BOOST_NO_RTTI
+#endif
+
+//
+// If we have a standard allocator, then we have a partial one as well:
+//
+#if !defined(BOOST_NO_STD_ALLOCATOR)
+#  define BOOST_HAS_PARTIAL_STD_ALLOCATOR
+#endif
+
+//
+// We can't have a working std::use_facet if there is no std::locale:
+//
+#  if defined(BOOST_NO_STD_LOCALE) && !defined(BOOST_NO_STD_USE_FACET)
+#     define BOOST_NO_STD_USE_FACET
+#  endif
+
+//
+// We can't have a std::messages facet if there is no std::locale:
+//
+#  if defined(BOOST_NO_STD_LOCALE) && !defined(BOOST_NO_STD_MESSAGES)
+#     define BOOST_NO_STD_MESSAGES
+#  endif
+
+//
+// We can't have a working std::wstreambuf if there is no std::locale:
+//
+#  if defined(BOOST_NO_STD_LOCALE) && !defined(BOOST_NO_STD_WSTREAMBUF)
+#     define BOOST_NO_STD_WSTREAMBUF
+#  endif
+
+//
+// We can't have a <cwctype> if there is no <cwchar>:
+//
+#  if defined(BOOST_NO_CWCHAR) && !defined(BOOST_NO_CWCTYPE)
+#     define BOOST_NO_CWCTYPE
+#  endif
+
+//
+// We can't have a swprintf if there is no <cwchar>:
+//
+#  if defined(BOOST_NO_CWCHAR) && !defined(BOOST_NO_SWPRINTF)
+#     define BOOST_NO_SWPRINTF
+#  endif
+
+//
+// If Win32 support is turned off, then we must turn off
+// threading support also, unless there is some other
+// thread API enabled:
+//
+#if defined(BOOST_DISABLE_WIN32) && defined(_WIN32) \
+   && !defined(BOOST_DISABLE_THREADS) && !defined(BOOST_HAS_PTHREADS)
+#  define BOOST_DISABLE_THREADS
+#endif
+
+//
+// Turn on threading support if the compiler thinks that it's in
+// multithreaded mode.  We put this here because there are only a
+// limited number of macros that identify this (if there's any missing
+// from here then add to the appropriate compiler section):
+//
+#if (defined(__MT__) || defined(_MT) || defined(_REENTRANT) \
+    || defined(_PTHREADS) || defined(__APPLE__) || defined(__DragonFly__)) \
+    && !defined(BOOST_HAS_THREADS)
+#  define BOOST_HAS_THREADS
+#endif
+
+//
+// Turn threading support off if BOOST_DISABLE_THREADS is defined:
+//
+#if defined(BOOST_DISABLE_THREADS) && defined(BOOST_HAS_THREADS)
+#  undef BOOST_HAS_THREADS
+#endif
+
+//
+// Turn threading support off if we don't recognise the threading API:
+//
+#if defined(BOOST_HAS_THREADS) && !defined(BOOST_HAS_PTHREADS)\
+      && !defined(BOOST_HAS_WINTHREADS) && !defined(BOOST_HAS_BETHREADS)\
+      && !defined(BOOST_HAS_MPTASKS)
+#  undef BOOST_HAS_THREADS
+#endif
+
+//
+// Turn threading detail macros off if we don't (want to) use threading
+//
+#ifndef BOOST_HAS_THREADS
+#  undef BOOST_HAS_PTHREADS
+#  undef BOOST_HAS_PTHREAD_MUTEXATTR_SETTYPE
+#  undef BOOST_HAS_PTHREAD_YIELD
+#  undef BOOST_HAS_PTHREAD_DELAY_NP
+#  undef BOOST_HAS_WINTHREADS
+#  undef BOOST_HAS_BETHREADS
+#  undef BOOST_HAS_MPTASKS
+#endif
+
+//
+// If the compiler claims to be C99 conformant, then it had better
+// have a <stdint.h>:
+//
+#  if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)
+#     define BOOST_HAS_STDINT_H
+#     ifndef BOOST_HAS_LOG1P
+#        define BOOST_HAS_LOG1P
+#     endif
+#     ifndef BOOST_HAS_EXPM1
+#        define BOOST_HAS_EXPM1
+#     endif
+#  endif
+
+//
+// Define BOOST_NO_SLIST and BOOST_NO_HASH if required.
+// Note that this is for backwards compatibility only.
+//
+#  if !defined(BOOST_HAS_SLIST) && !defined(BOOST_NO_SLIST)
+#     define BOOST_NO_SLIST
+#  endif
+
+#  if !defined(BOOST_HAS_HASH) && !defined(BOOST_NO_HASH)
+#     define BOOST_NO_HASH
+#  endif
+
+//
+// Set BOOST_SLIST_HEADER if not set already:
+//
+#if defined(BOOST_HAS_SLIST) && !defined(BOOST_SLIST_HEADER)
+#  define BOOST_SLIST_HEADER <slist>
+#endif
+
+//
+// Set BOOST_HASH_SET_HEADER if not set already:
+//
+#if defined(BOOST_HAS_HASH) && !defined(BOOST_HASH_SET_HEADER)
+#  define BOOST_HASH_SET_HEADER <hash_set>
+#endif
+
+//
+// Set BOOST_HASH_MAP_HEADER if not set already:
+//
+#if defined(BOOST_HAS_HASH) && !defined(BOOST_HASH_MAP_HEADER)
+#  define BOOST_HASH_MAP_HEADER <hash_map>
+#endif
+
+//  BOOST_HAS_ABI_HEADERS
+//  This macro gets set if we have headers that fix the ABI,
+//  and prevent ODR violations when linking to external libraries:
+#if defined(BOOST_ABI_PREFIX) && defined(BOOST_ABI_SUFFIX) && !defined(BOOST_HAS_ABI_HEADERS)
+#  define BOOST_HAS_ABI_HEADERS
+#endif
+
+#if defined(BOOST_HAS_ABI_HEADERS) && defined(BOOST_DISABLE_ABI_HEADERS)
+#  undef BOOST_HAS_ABI_HEADERS
+#endif
+
+//  BOOST_NO_STDC_NAMESPACE workaround  --------------------------------------//
+//  Because std::size_t usage is so common, even in boost headers which do not
+//  otherwise use the C library, the <cstddef> workaround is included here so
+//  that ugly workaround code need not appear in many other boost headers.
+//  NOTE WELL: This is a workaround for non-conforming compilers; <cstddef>
+//  must still be #included in the usual places so that <cstddef> inclusion
+//  works as expected with standard conforming compilers.  The resulting
+//  double inclusion of <cstddef> is harmless.
+
+# if defined(BOOST_NO_STDC_NAMESPACE) && defined(__cplusplus)
+#   include <cstddef>
+    namespace std { using ::ptrdiff_t; using ::size_t; }
+# endif
+
+//  Workaround for the unfortunate min/max macros defined by some platform headers
+
+#define BOOST_PREVENT_MACRO_SUBSTITUTION
+
+#ifndef BOOST_USING_STD_MIN
+#  define BOOST_USING_STD_MIN() using std::min
+#endif
+
+#ifndef BOOST_USING_STD_MAX
+#  define BOOST_USING_STD_MAX() using std::max
+#endif
+
+//  BOOST_NO_STD_MIN_MAX workaround  -----------------------------------------//
+
+#  if defined(BOOST_NO_STD_MIN_MAX) && defined(__cplusplus)
+
+namespace std {
+  template <class _Tp>
+  inline const _Tp& min BOOST_PREVENT_MACRO_SUBSTITUTION (const _Tp& __a, const _Tp& __b) {
+    return __b < __a ? __b : __a;
+  }
+  template <class _Tp>
+  inline const _Tp& max BOOST_PREVENT_MACRO_SUBSTITUTION (const _Tp& __a, const _Tp& __b) {
+    return  __a < __b ? __b : __a;
+  }
+}
+
+#  endif
+
+// BOOST_STATIC_CONSTANT workaround --------------------------------------- //
+// On compilers which don't allow in-class initialization of static integral
+// constant members, we must use enums as a workaround if we want the constants
+// to be available at compile-time. This macro gives us a convenient way to
+// declare such constants.
+
+#  ifdef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
+#       define BOOST_STATIC_CONSTANT(type, assignment) enum { assignment }
+#  else
+#     define BOOST_STATIC_CONSTANT(type, assignment) static const type assignment
+#  endif
+
+// BOOST_USE_FACET / HAS_FACET workaround ----------------------------------//
+// When the standard library does not have a conforming std::use_facet there
+// are various workarounds available, but they differ from library to library.
+// The same problem occurs with has_facet.
+// These macros provide a consistent way to access a locale's facets.
+// Usage:
+//    replace
+//       std::use_facet<Type>(loc);
+//    with
+//       BOOST_USE_FACET(Type, loc);
+//    Note do not add a std:: prefix to the front of BOOST_USE_FACET!
+//  Use for BOOST_HAS_FACET is analogous.
+
+#if defined(BOOST_NO_STD_USE_FACET)
+#  ifdef BOOST_HAS_TWO_ARG_USE_FACET
+#     define BOOST_USE_FACET(Type, loc) std::use_facet(loc, static_cast<Type*>(0))
+#     define BOOST_HAS_FACET(Type, loc) std::has_facet(loc, static_cast<Type*>(0))
+#  elif defined(BOOST_HAS_MACRO_USE_FACET)
+#     define BOOST_USE_FACET(Type, loc) std::_USE(loc, Type)
+#     define BOOST_HAS_FACET(Type, loc) std::_HAS(loc, Type)
+#  elif defined(BOOST_HAS_STLP_USE_FACET)
+#     define BOOST_USE_FACET(Type, loc) (*std::_Use_facet<Type >(loc))
+#     define BOOST_HAS_FACET(Type, loc) std::has_facet< Type >(loc)
+#  endif
+#else
+#  define BOOST_USE_FACET(Type, loc) std::use_facet< Type >(loc)
+#  define BOOST_HAS_FACET(Type, loc) std::has_facet< Type >(loc)
+#endif
+
+// BOOST_NESTED_TEMPLATE workaround ------------------------------------------//
+// Member templates are supported by some compilers even though they can't use
+// the A::template member<U> syntax, as a workaround replace:
+//
+// typedef typename A::template rebind<U> binder;
+//
+// with:
+//
+// typedef typename A::BOOST_NESTED_TEMPLATE rebind<U> binder;
+
+#ifndef BOOST_NO_MEMBER_TEMPLATE_KEYWORD
+#  define BOOST_NESTED_TEMPLATE template
+#else
+#  define BOOST_NESTED_TEMPLATE
+#endif
+
+// BOOST_UNREACHABLE_RETURN(x) workaround -------------------------------------//
+// Normally evaluates to nothing, unless BOOST_NO_UNREACHABLE_RETURN_DETECTION
+// is defined, in which case it evaluates to return x; Use when you have a return
+// statement that can never be reached.
+
+#ifndef BOOST_UNREACHABLE_RETURN
+#  ifdef BOOST_NO_UNREACHABLE_RETURN_DETECTION
+#     define BOOST_UNREACHABLE_RETURN(x) return x;
+#  else
+#     define BOOST_UNREACHABLE_RETURN(x)
+#  endif
+#endif
+
+// BOOST_DEDUCED_TYPENAME workaround ------------------------------------------//
+//
+// Some compilers don't support the use of `typename' for dependent
+// types in deduced contexts, e.g.
+//
+//     template <class T> void f(T, typename T::type);
+//                                  ^^^^^^^^
+// Replace these declarations with:
+//
+//     template <class T> void f(T, BOOST_DEDUCED_TYPENAME T::type);
+
+#ifndef BOOST_NO_DEDUCED_TYPENAME
+#  define BOOST_DEDUCED_TYPENAME typename
+#else
+#  define BOOST_DEDUCED_TYPENAME
+#endif
+
+#ifndef BOOST_NO_TYPENAME_WITH_CTOR
+#  define BOOST_CTOR_TYPENAME typename
+#else
+#  define BOOST_CTOR_TYPENAME
+#endif
+
+// long long workaround ------------------------------------------//
+// On gcc (and maybe other compilers?) long long is alway supported
+// but it's use may generate either warnings (with -ansi), or errors
+// (with -pedantic -ansi) unless it's use is prefixed by __extension__
+//
+#if defined(BOOST_HAS_LONG_LONG) && defined(__cplusplus)
+namespace boost{
+#  ifdef __GNUC__
+   __extension__ typedef long long long_long_type;
+   __extension__ typedef unsigned long long ulong_long_type;
+#  else
+   typedef long long long_long_type;
+   typedef unsigned long long ulong_long_type;
+#  endif
+}
+#endif
+// same again for __int128:
+#if defined(BOOST_HAS_INT128) && defined(__cplusplus)
+namespace boost{
+#  ifdef __GNUC__
+   __extension__ typedef __int128 int128_type;
+   __extension__ typedef unsigned __int128 uint128_type;
+#  else
+   typedef __int128 int128_type;
+   typedef unsigned __int128 uint128_type;
+#  endif
+}
+#endif
+// same again for __float128:
+#if defined(BOOST_HAS_FLOAT128) && defined(__cplusplus)
+namespace boost {
+#  ifdef __GNUC__
+   __extension__ typedef __float128 float128_type;
+#  else
+   typedef __float128 float128_type;
+#  endif
+}
+#endif
+
+// BOOST_[APPEND_]EXPLICIT_TEMPLATE_[NON_]TYPE macros --------------------------//
+
+// These macros are obsolete. Port away and remove.
+
+#  define BOOST_EXPLICIT_TEMPLATE_TYPE(t)
+#  define BOOST_EXPLICIT_TEMPLATE_TYPE_SPEC(t)
+#  define BOOST_EXPLICIT_TEMPLATE_NON_TYPE(t, v)
+#  define BOOST_EXPLICIT_TEMPLATE_NON_TYPE_SPEC(t, v)
+
+#  define BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE(t)
+#  define BOOST_APPEND_EXPLICIT_TEMPLATE_TYPE_SPEC(t)
+#  define BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE(t, v)
+#  define BOOST_APPEND_EXPLICIT_TEMPLATE_NON_TYPE_SPEC(t, v)
+
+// When BOOST_NO_STD_TYPEINFO is defined, we can just import
+// the global definition into std namespace:
+#if defined(BOOST_NO_STD_TYPEINFO) && defined(__cplusplus)
+#include <typeinfo>
+namespace std{ using ::type_info; }
+#endif
+
+// ---------------------------------------------------------------------------//
+
+// Helper macro BOOST_STRINGIZE:
+// Helper macro BOOST_JOIN:
+
+#include <boost/config/helper_macros.hpp>
+
+//
+// Set some default values for compiler/library/platform names.
+// These are for debugging config setup only:
+//
+#  ifndef BOOST_COMPILER
+#     define BOOST_COMPILER "Unknown ISO C++ Compiler"
+#  endif
+#  ifndef BOOST_STDLIB
+#     define BOOST_STDLIB "Unknown ISO standard library"
+#  endif
+#  ifndef BOOST_PLATFORM
+#     if defined(unix) || defined(__unix) || defined(_XOPEN_SOURCE) \
+         || defined(_POSIX_SOURCE)
+#        define BOOST_PLATFORM "Generic Unix"
+#     else
+#        define BOOST_PLATFORM "Unknown"
+#     endif
+#  endif
+
+//
+// Set some default values GPU support
+//
+#  ifndef BOOST_GPU_ENABLED
+#  define BOOST_GPU_ENABLED
+#  endif
+
+// BOOST_RESTRICT ---------------------------------------------//
+// Macro to use in place of 'restrict' keyword variants
+#if !defined(BOOST_RESTRICT)
+#  if defined(_MSC_VER)
+#    define BOOST_RESTRICT __restrict
+#    if !defined(BOOST_NO_RESTRICT_REFERENCES) && (_MSC_FULL_VER < 190023026)
+#      define BOOST_NO_RESTRICT_REFERENCES
+#    endif
+#  elif defined(__GNUC__) && __GNUC__ > 3
+     // Clang also defines __GNUC__ (as 4)
+#    define BOOST_RESTRICT __restrict__
+#  else
+#    define BOOST_RESTRICT
+#    if !defined(BOOST_NO_RESTRICT_REFERENCES)
+#      define BOOST_NO_RESTRICT_REFERENCES
+#    endif
+#  endif
+#endif
+
+// BOOST_MAY_ALIAS -----------------------------------------------//
+// The macro expands to an attribute to mark a type that is allowed to alias other types.
+// The macro is defined in the compiler-specific headers.
+#if !defined(BOOST_MAY_ALIAS)
+#  define BOOST_NO_MAY_ALIAS
+#  define BOOST_MAY_ALIAS
+#endif
+
+// BOOST_FORCEINLINE ---------------------------------------------//
+// Macro to use in place of 'inline' to force a function to be inline
+#if !defined(BOOST_FORCEINLINE)
+#  if defined(_MSC_VER)
+#    define BOOST_FORCEINLINE __forceinline
+#  elif defined(__GNUC__) && __GNUC__ > 3
+     // Clang also defines __GNUC__ (as 4)
+#    define BOOST_FORCEINLINE inline __attribute__ ((__always_inline__))
+#  else
+#    define BOOST_FORCEINLINE inline
+#  endif
+#endif
+
+// BOOST_NOINLINE ---------------------------------------------//
+// Macro to use in place of 'inline' to prevent a function to be inlined
+#if !defined(BOOST_NOINLINE)
+#  if defined(_MSC_VER)
+#    define BOOST_NOINLINE __declspec(noinline)
+#  elif defined(__GNUC__) && __GNUC__ > 3
+     // Clang also defines __GNUC__ (as 4)
+#    if defined(__CUDACC__)
+       // nvcc doesn't always parse __noinline__,
+       // see: https://svn.boost.org/trac/boost/ticket/9392
+#      define BOOST_NOINLINE __attribute__ ((noinline))
+#    else
+#      define BOOST_NOINLINE __attribute__ ((__noinline__))
+#    endif
+#  else
+#    define BOOST_NOINLINE
+#  endif
+#endif
+
+// BOOST_NORETURN ---------------------------------------------//
+// Macro to use before a function declaration/definition to designate
+// the function as not returning normally (i.e. with a return statement
+// or by leaving the function scope, if the function return type is void).
+#if !defined(BOOST_NORETURN)
+#  if defined(_MSC_VER)
+#    define BOOST_NORETURN __declspec(noreturn)
+#  elif defined(__GNUC__)
+#    define BOOST_NORETURN __attribute__ ((__noreturn__))
+#  elif defined(__has_attribute) && defined(__SUNPRO_CC) && (__SUNPRO_CC > 0x5130)
+#    if __has_attribute(noreturn)
+#      define BOOST_NORETURN [[noreturn]]
+#    endif
+#  elif defined(__has_cpp_attribute) 
+#    if __has_cpp_attribute(noreturn)
+#      define BOOST_NORETURN [[noreturn]]
+#    endif
+#  endif
+#endif
+
+#if !defined(BOOST_NORETURN)
+#  define BOOST_NO_NORETURN
+#  define BOOST_NORETURN
+#endif
+
+// Branch prediction hints
+// These macros are intended to wrap conditional expressions that yield true or false
+//
+//  if (BOOST_LIKELY(var == 10))
+//  {
+//     // the most probable code here
+//  }
+//
+#if !defined(BOOST_LIKELY)
+#  define BOOST_LIKELY(x) x
+#endif
+#if !defined(BOOST_UNLIKELY)
+#  define BOOST_UNLIKELY(x) x
+#endif
+
+// Type and data alignment specification
+//
+#if !defined(BOOST_ALIGNMENT)
+#  if !defined(BOOST_NO_CXX11_ALIGNAS)
+#    define BOOST_ALIGNMENT(x) alignas(x)
+#  elif defined(_MSC_VER)
+#    define BOOST_ALIGNMENT(x) __declspec(align(x))
+#  elif defined(__GNUC__)
+#    define BOOST_ALIGNMENT(x) __attribute__ ((__aligned__(x)))
+#  else
+#    define BOOST_NO_ALIGNMENT
+#    define BOOST_ALIGNMENT(x)
+#  endif
+#endif
+
+// Lack of non-public defaulted functions is implied by the lack of any defaulted functions
+#if !defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS) && defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS)
+#  define BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS
+#endif
+
+// Lack of defaulted moves is implied by the lack of either rvalue references or any defaulted functions
+#if !defined(BOOST_NO_CXX11_DEFAULTED_MOVES) && (defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES))
+#  define BOOST_NO_CXX11_DEFAULTED_MOVES
+#endif
+
+// Defaulted and deleted function declaration helpers
+// These macros are intended to be inside a class definition.
+// BOOST_DEFAULTED_FUNCTION accepts the function declaration and its
+// body, which will be used if the compiler doesn't support defaulted functions.
+// BOOST_DELETED_FUNCTION only accepts the function declaration. It
+// will expand to a private function declaration, if the compiler doesn't support
+// deleted functions. Because of this it is recommended to use BOOST_DELETED_FUNCTION
+// in the end of the class definition.
+//
+//  class my_class
+//  {
+//  public:
+//      // Default-constructible
+//      BOOST_DEFAULTED_FUNCTION(my_class(), {})
+//      // Copying prohibited
+//      BOOST_DELETED_FUNCTION(my_class(my_class const&))
+//      BOOST_DELETED_FUNCTION(my_class& operator= (my_class const&))
+//  };
+//
+#if !(defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) || defined(BOOST_NO_CXX11_NON_PUBLIC_DEFAULTED_FUNCTIONS))
+#   define BOOST_DEFAULTED_FUNCTION(fun, body) fun = default;
+#else
+#   define BOOST_DEFAULTED_FUNCTION(fun, body) fun body
+#endif
+
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+#   define BOOST_DELETED_FUNCTION(fun) fun = delete;
+#else
+#   define BOOST_DELETED_FUNCTION(fun) private: fun;
+#endif
+
+//
+// Set BOOST_NO_DECLTYPE_N3276 when BOOST_NO_DECLTYPE is defined
+//
+#if defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_CXX11_DECLTYPE_N3276)
+#define BOOST_NO_CXX11_DECLTYPE_N3276 BOOST_NO_CXX11_DECLTYPE
+#endif
+
+//  -------------------- Deprecated macros for 1.50 ---------------------------
+//  These will go away in a future release
+
+//  Use BOOST_NO_CXX11_HDR_UNORDERED_SET or BOOST_NO_CXX11_HDR_UNORDERED_MAP
+//           instead of BOOST_NO_STD_UNORDERED
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_MAP) || defined (BOOST_NO_CXX11_HDR_UNORDERED_SET)
+# ifndef BOOST_NO_CXX11_STD_UNORDERED
+#  define BOOST_NO_CXX11_STD_UNORDERED
+# endif
+#endif
+
+//  Use BOOST_NO_CXX11_HDR_INITIALIZER_LIST instead of BOOST_NO_INITIALIZER_LISTS
+#if defined(BOOST_NO_CXX11_HDR_INITIALIZER_LIST) && !defined(BOOST_NO_INITIALIZER_LISTS)
+#  define BOOST_NO_INITIALIZER_LISTS
+#endif
+
+//  Use BOOST_NO_CXX11_HDR_ARRAY instead of BOOST_NO_0X_HDR_ARRAY
+#if defined(BOOST_NO_CXX11_HDR_ARRAY) && !defined(BOOST_NO_0X_HDR_ARRAY)
+#  define BOOST_NO_0X_HDR_ARRAY
+#endif
+//  Use BOOST_NO_CXX11_HDR_CHRONO instead of BOOST_NO_0X_HDR_CHRONO
+#if defined(BOOST_NO_CXX11_HDR_CHRONO) && !defined(BOOST_NO_0X_HDR_CHRONO)
+#  define BOOST_NO_0X_HDR_CHRONO
+#endif
+//  Use BOOST_NO_CXX11_HDR_CODECVT instead of BOOST_NO_0X_HDR_CODECVT
+#if defined(BOOST_NO_CXX11_HDR_CODECVT) && !defined(BOOST_NO_0X_HDR_CODECVT)
+#  define BOOST_NO_0X_HDR_CODECVT
+#endif
+//  Use BOOST_NO_CXX11_HDR_CONDITION_VARIABLE instead of BOOST_NO_0X_HDR_CONDITION_VARIABLE
+#if defined(BOOST_NO_CXX11_HDR_CONDITION_VARIABLE) && !defined(BOOST_NO_0X_HDR_CONDITION_VARIABLE)
+#  define BOOST_NO_0X_HDR_CONDITION_VARIABLE
+#endif
+//  Use BOOST_NO_CXX11_HDR_FORWARD_LIST instead of BOOST_NO_0X_HDR_FORWARD_LIST
+#if defined(BOOST_NO_CXX11_HDR_FORWARD_LIST) && !defined(BOOST_NO_0X_HDR_FORWARD_LIST)
+#  define BOOST_NO_0X_HDR_FORWARD_LIST
+#endif
+//  Use BOOST_NO_CXX11_HDR_FUTURE instead of BOOST_NO_0X_HDR_FUTURE
+#if defined(BOOST_NO_CXX11_HDR_FUTURE) && !defined(BOOST_NO_0X_HDR_FUTURE)
+#  define BOOST_NO_0X_HDR_FUTURE
+#endif
+
+//  Use BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+//  instead of BOOST_NO_0X_HDR_INITIALIZER_LIST or BOOST_NO_INITIALIZER_LISTS
+#ifdef BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+# ifndef BOOST_NO_0X_HDR_INITIALIZER_LIST
+#  define BOOST_NO_0X_HDR_INITIALIZER_LIST
+# endif
+# ifndef BOOST_NO_INITIALIZER_LISTS
+#  define BOOST_NO_INITIALIZER_LISTS
+# endif
+#endif
+
+//  Use BOOST_NO_CXX11_HDR_MUTEX instead of BOOST_NO_0X_HDR_MUTEX
+#if defined(BOOST_NO_CXX11_HDR_MUTEX) && !defined(BOOST_NO_0X_HDR_MUTEX)
+#  define BOOST_NO_0X_HDR_MUTEX
+#endif
+//  Use BOOST_NO_CXX11_HDR_RANDOM instead of BOOST_NO_0X_HDR_RANDOM
+#if defined(BOOST_NO_CXX11_HDR_RANDOM) && !defined(BOOST_NO_0X_HDR_RANDOM)
+#  define BOOST_NO_0X_HDR_RANDOM
+#endif
+//  Use BOOST_NO_CXX11_HDR_RATIO instead of BOOST_NO_0X_HDR_RATIO
+#if defined(BOOST_NO_CXX11_HDR_RATIO) && !defined(BOOST_NO_0X_HDR_RATIO)
+#  define BOOST_NO_0X_HDR_RATIO
+#endif
+//  Use BOOST_NO_CXX11_HDR_REGEX instead of BOOST_NO_0X_HDR_REGEX
+#if defined(BOOST_NO_CXX11_HDR_REGEX) && !defined(BOOST_NO_0X_HDR_REGEX)
+#  define BOOST_NO_0X_HDR_REGEX
+#endif
+//  Use BOOST_NO_CXX11_HDR_SYSTEM_ERROR instead of BOOST_NO_0X_HDR_SYSTEM_ERROR
+#if defined(BOOST_NO_CXX11_HDR_SYSTEM_ERROR) && !defined(BOOST_NO_0X_HDR_SYSTEM_ERROR)
+#  define BOOST_NO_0X_HDR_SYSTEM_ERROR
+#endif
+//  Use BOOST_NO_CXX11_HDR_THREAD instead of BOOST_NO_0X_HDR_THREAD
+#if defined(BOOST_NO_CXX11_HDR_THREAD) && !defined(BOOST_NO_0X_HDR_THREAD)
+#  define BOOST_NO_0X_HDR_THREAD
+#endif
+//  Use BOOST_NO_CXX11_HDR_TUPLE instead of BOOST_NO_0X_HDR_TUPLE
+#if defined(BOOST_NO_CXX11_HDR_TUPLE) && !defined(BOOST_NO_0X_HDR_TUPLE)
+#  define BOOST_NO_0X_HDR_TUPLE
+#endif
+//  Use BOOST_NO_CXX11_HDR_TYPE_TRAITS instead of BOOST_NO_0X_HDR_TYPE_TRAITS
+#if defined(BOOST_NO_CXX11_HDR_TYPE_TRAITS) && !defined(BOOST_NO_0X_HDR_TYPE_TRAITS)
+#  define BOOST_NO_0X_HDR_TYPE_TRAITS
+#endif
+//  Use BOOST_NO_CXX11_HDR_TYPEINDEX instead of BOOST_NO_0X_HDR_TYPEINDEX
+#if defined(BOOST_NO_CXX11_HDR_TYPEINDEX) && !defined(BOOST_NO_0X_HDR_TYPEINDEX)
+#  define BOOST_NO_0X_HDR_TYPEINDEX
+#endif
+//  Use BOOST_NO_CXX11_HDR_UNORDERED_MAP instead of BOOST_NO_0X_HDR_UNORDERED_MAP
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_MAP) && !defined(BOOST_NO_0X_HDR_UNORDERED_MAP)
+#  define BOOST_NO_0X_HDR_UNORDERED_MAP
+#endif
+//  Use BOOST_NO_CXX11_HDR_UNORDERED_SET instead of BOOST_NO_0X_HDR_UNORDERED_SET
+#if defined(BOOST_NO_CXX11_HDR_UNORDERED_SET) && !defined(BOOST_NO_0X_HDR_UNORDERED_SET)
+#  define BOOST_NO_0X_HDR_UNORDERED_SET
+#endif
+
+//  ------------------ End of deprecated macros for 1.50 ---------------------------
+
+//  -------------------- Deprecated macros for 1.51 ---------------------------
+//  These will go away in a future release
+
+//  Use     BOOST_NO_CXX11_AUTO_DECLARATIONS instead of   BOOST_NO_AUTO_DECLARATIONS
+#if defined(BOOST_NO_CXX11_AUTO_DECLARATIONS) && !defined(BOOST_NO_AUTO_DECLARATIONS)
+#  define BOOST_NO_AUTO_DECLARATIONS
+#endif
+//  Use     BOOST_NO_CXX11_AUTO_MULTIDECLARATIONS instead of   BOOST_NO_AUTO_MULTIDECLARATIONS
+#if defined(BOOST_NO_CXX11_AUTO_MULTIDECLARATIONS) && !defined(BOOST_NO_AUTO_MULTIDECLARATIONS)
+#  define BOOST_NO_AUTO_MULTIDECLARATIONS
+#endif
+//  Use     BOOST_NO_CXX11_CHAR16_T instead of   BOOST_NO_CHAR16_T
+#if defined(BOOST_NO_CXX11_CHAR16_T) && !defined(BOOST_NO_CHAR16_T)
+#  define BOOST_NO_CHAR16_T
+#endif
+//  Use     BOOST_NO_CXX11_CHAR32_T instead of   BOOST_NO_CHAR32_T
+#if defined(BOOST_NO_CXX11_CHAR32_T) && !defined(BOOST_NO_CHAR32_T)
+#  define BOOST_NO_CHAR32_T
+#endif
+//  Use     BOOST_NO_CXX11_TEMPLATE_ALIASES instead of   BOOST_NO_TEMPLATE_ALIASES
+#if defined(BOOST_NO_CXX11_TEMPLATE_ALIASES) && !defined(BOOST_NO_TEMPLATE_ALIASES)
+#  define BOOST_NO_TEMPLATE_ALIASES
+#endif
+//  Use     BOOST_NO_CXX11_CONSTEXPR instead of   BOOST_NO_CONSTEXPR
+#if defined(BOOST_NO_CXX11_CONSTEXPR) && !defined(BOOST_NO_CONSTEXPR)
+#  define BOOST_NO_CONSTEXPR
+#endif
+//  Use     BOOST_NO_CXX11_DECLTYPE_N3276 instead of   BOOST_NO_DECLTYPE_N3276
+#if defined(BOOST_NO_CXX11_DECLTYPE_N3276) && !defined(BOOST_NO_DECLTYPE_N3276)
+#  define BOOST_NO_DECLTYPE_N3276
+#endif
+//  Use     BOOST_NO_CXX11_DECLTYPE instead of   BOOST_NO_DECLTYPE
+#if defined(BOOST_NO_CXX11_DECLTYPE) && !defined(BOOST_NO_DECLTYPE)
+#  define BOOST_NO_DECLTYPE
+#endif
+//  Use     BOOST_NO_CXX11_DEFAULTED_FUNCTIONS instead of   BOOST_NO_DEFAULTED_FUNCTIONS
+#if defined(BOOST_NO_CXX11_DEFAULTED_FUNCTIONS) && !defined(BOOST_NO_DEFAULTED_FUNCTIONS)
+#  define BOOST_NO_DEFAULTED_FUNCTIONS
+#endif
+//  Use     BOOST_NO_CXX11_DELETED_FUNCTIONS instead of   BOOST_NO_DELETED_FUNCTIONS
+#if defined(BOOST_NO_CXX11_DELETED_FUNCTIONS) && !defined(BOOST_NO_DELETED_FUNCTIONS)
+#  define BOOST_NO_DELETED_FUNCTIONS
+#endif
+//  Use     BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS instead of   BOOST_NO_EXPLICIT_CONVERSION_OPERATORS
+#if defined(BOOST_NO_CXX11_EXPLICIT_CONVERSION_OPERATORS) && !defined(BOOST_NO_EXPLICIT_CONVERSION_OPERATORS)
+#  define BOOST_NO_EXPLICIT_CONVERSION_OPERATORS
+#endif
+//  Use     BOOST_NO_CXX11_EXTERN_TEMPLATE instead of   BOOST_NO_EXTERN_TEMPLATE
+#if defined(BOOST_NO_CXX11_EXTERN_TEMPLATE) && !defined(BOOST_NO_EXTERN_TEMPLATE)
+#  define BOOST_NO_EXTERN_TEMPLATE
+#endif
+//  Use     BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS instead of   BOOST_NO_FUNCTION_TEMPLATE_DEFAULT_ARGS
+#if defined(BOOST_NO_CXX11_FUNCTION_TEMPLATE_DEFAULT_ARGS) && !defined(BOOST_NO_FUNCTION_TEMPLATE_DEFAULT_ARGS)
+#  define BOOST_NO_FUNCTION_TEMPLATE_DEFAULT_ARGS
+#endif
+//  Use     BOOST_NO_CXX11_LAMBDAS instead of   BOOST_NO_LAMBDAS
+#if defined(BOOST_NO_CXX11_LAMBDAS) && !defined(BOOST_NO_LAMBDAS)
+#  define BOOST_NO_LAMBDAS
+#endif
+//  Use     BOOST_NO_CXX11_LOCAL_CLASS_TEMPLATE_PARAMETERS instead of   BOOST_NO_LOCAL_CLASS_TEMPLATE_PARAMETERS
+#if defined(BOOST_NO_CXX11_LOCAL_CLASS_TEMPLATE_PARAMETERS) && !defined(BOOST_NO_LOCAL_CLASS_TEMPLATE_PARAMETERS)
+#  define BOOST_NO_LOCAL_CLASS_TEMPLATE_PARAMETERS
+#endif
+//  Use     BOOST_NO_CXX11_NOEXCEPT instead of   BOOST_NO_NOEXCEPT
+#if defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_NOEXCEPT)
+#  define BOOST_NO_NOEXCEPT
+#endif
+//  Use     BOOST_NO_CXX11_NULLPTR instead of   BOOST_NO_NULLPTR
+#if defined(BOOST_NO_CXX11_NULLPTR) && !defined(BOOST_NO_NULLPTR)
+#  define BOOST_NO_NULLPTR
+#endif
+//  Use     BOOST_NO_CXX11_RAW_LITERALS instead of   BOOST_NO_RAW_LITERALS
+#if defined(BOOST_NO_CXX11_RAW_LITERALS) && !defined(BOOST_NO_RAW_LITERALS)
+#  define BOOST_NO_RAW_LITERALS
+#endif
+//  Use     BOOST_NO_CXX11_RVALUE_REFERENCES instead of   BOOST_NO_RVALUE_REFERENCES
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_RVALUE_REFERENCES)
+#  define BOOST_NO_RVALUE_REFERENCES
+#endif
+//  Use     BOOST_NO_CXX11_SCOPED_ENUMS instead of   BOOST_NO_SCOPED_ENUMS
+#if defined(BOOST_NO_CXX11_SCOPED_ENUMS) && !defined(BOOST_NO_SCOPED_ENUMS)
+#  define BOOST_NO_SCOPED_ENUMS
+#endif
+//  Use     BOOST_NO_CXX11_STATIC_ASSERT instead of   BOOST_NO_STATIC_ASSERT
+#if defined(BOOST_NO_CXX11_STATIC_ASSERT) && !defined(BOOST_NO_STATIC_ASSERT)
+#  define BOOST_NO_STATIC_ASSERT
+#endif
+//  Use     BOOST_NO_CXX11_STD_UNORDERED instead of   BOOST_NO_STD_UNORDERED
+#if defined(BOOST_NO_CXX11_STD_UNORDERED) && !defined(BOOST_NO_STD_UNORDERED)
+#  define BOOST_NO_STD_UNORDERED
+#endif
+//  Use     BOOST_NO_CXX11_UNICODE_LITERALS instead of   BOOST_NO_UNICODE_LITERALS
+#if defined(BOOST_NO_CXX11_UNICODE_LITERALS) && !defined(BOOST_NO_UNICODE_LITERALS)
+#  define BOOST_NO_UNICODE_LITERALS
+#endif
+//  Use     BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX instead of   BOOST_NO_UNIFIED_INITIALIZATION_SYNTAX
+#if defined(BOOST_NO_CXX11_UNIFIED_INITIALIZATION_SYNTAX) && !defined(BOOST_NO_UNIFIED_INITIALIZATION_SYNTAX)
+#  define BOOST_NO_UNIFIED_INITIALIZATION_SYNTAX
+#endif
+//  Use     BOOST_NO_CXX11_VARIADIC_TEMPLATES instead of   BOOST_NO_VARIADIC_TEMPLATES
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_VARIADIC_TEMPLATES)
+#  define BOOST_NO_VARIADIC_TEMPLATES
+#endif
+//  Use     BOOST_NO_CXX11_VARIADIC_MACROS instead of   BOOST_NO_VARIADIC_MACROS
+#if defined(BOOST_NO_CXX11_VARIADIC_MACROS) && !defined(BOOST_NO_VARIADIC_MACROS)
+#  define BOOST_NO_VARIADIC_MACROS
+#endif
+//  Use     BOOST_NO_CXX11_NUMERIC_LIMITS instead of   BOOST_NO_NUMERIC_LIMITS_LOWEST
+#if defined(BOOST_NO_CXX11_NUMERIC_LIMITS) && !defined(BOOST_NO_NUMERIC_LIMITS_LOWEST)
+#  define BOOST_NO_NUMERIC_LIMITS_LOWEST
+#endif
+//  ------------------ End of deprecated macros for 1.51 ---------------------------
+
+
+
+//
+// Helper macros BOOST_NOEXCEPT, BOOST_NOEXCEPT_IF, BOOST_NOEXCEPT_EXPR
+// These aid the transition to C++11 while still supporting C++03 compilers
+//
+#ifdef BOOST_NO_CXX11_NOEXCEPT
+#  define BOOST_NOEXCEPT
+#  define BOOST_NOEXCEPT_OR_NOTHROW throw()
+#  define BOOST_NOEXCEPT_IF(Predicate)
+#  define BOOST_NOEXCEPT_EXPR(Expression) false
+#else
+#  define BOOST_NOEXCEPT noexcept
+#  define BOOST_NOEXCEPT_OR_NOTHROW noexcept
+#  define BOOST_NOEXCEPT_IF(Predicate) noexcept((Predicate))
+#  define BOOST_NOEXCEPT_EXPR(Expression) noexcept((Expression))
+#endif
+//
+// Helper macro BOOST_FALLTHROUGH
+// Fallback definition of BOOST_FALLTHROUGH macro used to mark intended
+// fall-through between case labels in a switch statement. We use a definition
+// that requires a semicolon after it to avoid at least one type of misuse even
+// on unsupported compilers.
+//
+#ifndef BOOST_FALLTHROUGH
+#  define BOOST_FALLTHROUGH ((void)0)
+#endif
+
+//
+// constexpr workarounds
+//
+#if defined(BOOST_NO_CXX11_CONSTEXPR)
+#define BOOST_CONSTEXPR
+#define BOOST_CONSTEXPR_OR_CONST const
+#else
+#define BOOST_CONSTEXPR constexpr
+#define BOOST_CONSTEXPR_OR_CONST constexpr
+#endif
+#if defined(BOOST_NO_CXX14_CONSTEXPR)
+#define BOOST_CXX14_CONSTEXPR
+#else
+#define BOOST_CXX14_CONSTEXPR constexpr
+#endif
+
+//
+// Unused variable/typedef workarounds:
+//
+#ifndef BOOST_ATTRIBUTE_UNUSED
+#  define BOOST_ATTRIBUTE_UNUSED
+#endif
+
+#define BOOST_STATIC_CONSTEXPR  static BOOST_CONSTEXPR_OR_CONST
+
+//
+// Set BOOST_HAS_STATIC_ASSERT when BOOST_NO_CXX11_STATIC_ASSERT is not defined
+//
+#if !defined(BOOST_NO_CXX11_STATIC_ASSERT) && !defined(BOOST_HAS_STATIC_ASSERT)
+#  define BOOST_HAS_STATIC_ASSERT
+#endif
+
+//
+// Set BOOST_HAS_RVALUE_REFS when BOOST_NO_CXX11_RVALUE_REFERENCES is not defined
+//
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_HAS_RVALUE_REFS)
+#define BOOST_HAS_RVALUE_REFS
+#endif
+
+//
+// Set BOOST_HAS_VARIADIC_TMPL when BOOST_NO_CXX11_VARIADIC_TEMPLATES is not defined
+//
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_HAS_VARIADIC_TMPL)
+#define BOOST_HAS_VARIADIC_TMPL
+#endif
+//
+// Set BOOST_NO_CXX11_FIXED_LENGTH_VARIADIC_TEMPLATE_EXPANSION_PACKS when
+// BOOST_NO_CXX11_VARIADIC_TEMPLATES is set:
+//
+#if defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES) && !defined(BOOST_NO_CXX11_FIXED_LENGTH_VARIADIC_TEMPLATE_EXPANSION_PACKS)
+#  define BOOST_NO_CXX11_FIXED_LENGTH_VARIADIC_TEMPLATE_EXPANSION_PACKS
+#endif
+
+//
+// Finish off with checks for macros that are depricated / no longer supported,
+// if any of these are set then it's very likely that much of Boost will no
+// longer work.  So stop with a #error for now, but give the user a chance
+// to continue at their own risk if they really want to:
+//
+#if defined(BOOST_NO_TEMPLATE_PARTIAL_SPECIALIZATION) && !defined(BOOST_CONFIG_ALLOW_DEPRECATED)
+#  error "You are using a compiler which lacks features which are now a minimum requirement in order to use Boost, define BOOST_CONFIG_ALLOW_DEPRECATED if you want to continue at your own risk!!!"
+#endif
+
+#endif

--- a/src/boost/config/helper_macros.hpp
+++ b/src/boost/config/helper_macros.hpp
@@ -1,0 +1,37 @@
+#ifndef BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED
+#define BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED
+
+//  Copyright 2001 John Maddock.
+//  Copyright 2017 Peter Dimov.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  BOOST_STRINGIZE(X)
+//  BOOST_JOIN(X, Y)
+//
+//  Note that this header is C compatible.
+
+//
+// Helper macro BOOST_STRINGIZE:
+// Converts the parameter X to a string after macro replacement
+// on X has been performed.
+//
+#define BOOST_STRINGIZE(X) BOOST_DO_STRINGIZE(X)
+#define BOOST_DO_STRINGIZE(X) #X
+
+//
+// Helper macro BOOST_JOIN:
+// The following piece of macro magic joins the two
+// arguments together, even when one of the arguments is
+// itself a macro (see 16.3.1 in C++ standard).  The key
+// is that macro expansion of macro arguments does not
+// occur in BOOST_DO_JOIN2 but does in BOOST_DO_JOIN.
+//
+#define BOOST_JOIN(X, Y) BOOST_DO_JOIN(X, Y)
+#define BOOST_DO_JOIN(X, Y) BOOST_DO_JOIN2(X,Y)
+#define BOOST_DO_JOIN2(X, Y) X##Y
+
+#endif // BOOST_CONFIG_HELPER_MACROS_HPP_INCLUDED

--- a/src/boost/config/platform/linux.hpp
+++ b/src/boost/config/platform/linux.hpp
@@ -1,0 +1,106 @@
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  (C) Copyright Jens Maurer 2001 - 2003. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+//  linux specific config options:
+
+#define BOOST_PLATFORM "linux"
+
+// make sure we have __GLIBC_PREREQ if available at all
+#ifdef __cplusplus
+#include <cstdlib>
+#else
+#include <stdlib.h>
+#endif
+
+//
+// <stdint.h> added to glibc 2.1.1
+// We can only test for 2.1 though:
+//
+#if defined(__GLIBC__) && ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 1)))
+   // <stdint.h> defines int64_t unconditionally, but <sys/types.h> defines
+   // int64_t only if __GNUC__.  Thus, assume a fully usable <stdint.h>
+   // only when using GCC.  Update 2017: this appears not to be the case for
+   // recent glibc releases, see bug report: https://svn.boost.org/trac/boost/ticket/13045
+#  if defined(__GNUC__) || ((__GLIBC__ > 2) || ((__GLIBC__ == 2) && (__GLIBC_MINOR__ >= 5)))
+#    define BOOST_HAS_STDINT_H
+#  endif
+#endif
+
+#if defined(__LIBCOMO__)
+   //
+   // como on linux doesn't have std:: c functions:
+   // NOTE: versions of libcomo prior to beta28 have octal version numbering,
+   // e.g. version 25 is 21 (dec)
+   //
+#  if __LIBCOMO_VERSION__ <= 20
+#    define BOOST_NO_STDC_NAMESPACE
+#  endif
+
+#  if __LIBCOMO_VERSION__ <= 21
+#    define BOOST_NO_SWPRINTF
+#  endif
+
+#endif
+
+//
+// If glibc is past version 2 then we definitely have
+// gettimeofday, earlier versions may or may not have it:
+//
+#if defined(__GLIBC__) && (__GLIBC__ >= 2)
+#  define BOOST_HAS_GETTIMEOFDAY
+#endif
+
+#ifdef __USE_POSIX199309
+#  define BOOST_HAS_NANOSLEEP
+#endif
+
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+// __GLIBC_PREREQ is available since 2.1.2
+
+   // swprintf is available since glibc 2.2.0
+#  if !__GLIBC_PREREQ(2,2) || (!defined(__USE_ISOC99) && !defined(__USE_UNIX98))
+#    define BOOST_NO_SWPRINTF
+#  endif
+#else
+#  define BOOST_NO_SWPRINTF
+#endif
+
+// boilerplate code:
+#define BOOST_HAS_UNISTD_H
+#include <boost/config/detail/posix_features.hpp>
+#if defined(__USE_GNU) && !defined(__ANDROID__) && !defined(ANDROID)
+#define BOOST_HAS_PTHREAD_YIELD
+#endif
+
+#ifndef __GNUC__
+//
+// if the compiler is not gcc we still need to be able to parse
+// the GNU system headers, some of which (mainly <stdint.h>)
+// use GNU specific extensions:
+//
+#  ifndef __extension__
+#     define __extension__
+#  endif
+#  ifndef __const__
+#     define __const__ const
+#  endif
+#  ifndef __volatile__
+#     define __volatile__ volatile
+#  endif
+#  ifndef __signed__
+#     define __signed__ signed
+#  endif
+#  ifndef __typeof__
+#     define __typeof__ typeof
+#  endif
+#  ifndef __inline__
+#     define __inline__ inline
+#  endif
+#endif
+
+

--- a/src/boost/config/platform/macos.hpp
+++ b/src/boost/config/platform/macos.hpp
@@ -1,0 +1,87 @@
+//  (C) Copyright John Maddock 2001 - 2003. 
+//  (C) Copyright Darin Adler 2001 - 2002. 
+//  (C) Copyright Bill Kempf 2002. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+//  Mac OS specific config options:
+
+#define BOOST_PLATFORM "Mac OS"
+
+#if __MACH__ && !defined(_MSL_USING_MSL_C)
+
+// Using the Mac OS X system BSD-style C library.
+
+#  ifndef BOOST_HAS_UNISTD_H
+#    define BOOST_HAS_UNISTD_H
+#  endif
+//
+// Begin by including our boilerplate code for POSIX
+// feature detection, this is safe even when using
+// the MSL as Metrowerks supply their own <unistd.h>
+// to replace the platform-native BSD one. G++ users
+// should also always be able to do this on MaxOS X.
+//
+#  include <boost/config/detail/posix_features.hpp>
+#  ifndef BOOST_HAS_STDINT_H
+#     define BOOST_HAS_STDINT_H
+#  endif
+
+//
+// BSD runtime has pthreads, sigaction, sched_yield and gettimeofday,
+// of these only pthreads are advertised in <unistd.h>, so set the 
+// other options explicitly:
+//
+#  define BOOST_HAS_SCHED_YIELD
+#  define BOOST_HAS_GETTIMEOFDAY
+#  define BOOST_HAS_SIGACTION
+
+#  if (__GNUC__ < 3) && !defined( __APPLE_CC__)
+
+// GCC strange "ignore std" mode works better if you pretend everything
+// is in the std namespace, for the most part.
+
+#    define BOOST_NO_STDC_NAMESPACE
+#  endif
+
+#  if (__GNUC__ >= 4)
+
+// Both gcc and intel require these.  
+#    define BOOST_HAS_PTHREAD_MUTEXATTR_SETTYPE
+#    define BOOST_HAS_NANOSLEEP
+
+#  endif
+
+#else
+
+// Using the MSL C library.
+
+// We will eventually support threads in non-Carbon builds, but we do
+// not support this yet.
+#  if ( defined(TARGET_API_MAC_CARBON) && TARGET_API_MAC_CARBON ) || ( defined(TARGET_CARBON) && TARGET_CARBON )
+
+#  if !defined(BOOST_HAS_PTHREADS)
+// MPTasks support is deprecated/removed from Boost:
+//#    define BOOST_HAS_MPTASKS
+#  elif ( __dest_os == __mac_os_x )
+// We are doing a Carbon/Mach-O/MSL build which has pthreads, but only the
+// gettimeofday and no posix.
+#  define BOOST_HAS_GETTIMEOFDAY
+#  endif
+
+#ifdef BOOST_HAS_PTHREADS
+#  define BOOST_HAS_THREADS
+#endif
+
+// The remote call manager depends on this.
+#    define BOOST_BIND_ENABLE_PASCAL
+
+#  endif
+
+#endif
+
+
+

--- a/src/boost/config/stdlib/libcpp.hpp
+++ b/src/boost/config/stdlib/libcpp.hpp
@@ -1,0 +1,133 @@
+//  (C) Copyright Christopher Jefferson 2011.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+//  config for libc++
+//  Might need more in here later.
+
+#if !defined(_LIBCPP_VERSION)
+#  include <ciso646>
+#  if !defined(_LIBCPP_VERSION)
+#      error "This is not libc++!"
+#  endif
+#endif
+
+#define BOOST_STDLIB "libc++ version " BOOST_STRINGIZE(_LIBCPP_VERSION)
+
+#define BOOST_HAS_THREADS
+
+#ifdef _LIBCPP_HAS_NO_VARIADICS
+#    define BOOST_NO_CXX11_HDR_TUPLE
+#endif
+
+// BOOST_NO_CXX11_ALLOCATOR should imply no support for the C++11
+// allocator model. The C++11 allocator model requires a conforming
+// std::allocator_traits which is only possible with C++11 template
+// aliases since members rebind_alloc and rebind_traits require it.
+#if defined(_LIBCPP_HAS_NO_TEMPLATE_ALIASES)
+#    define BOOST_NO_CXX11_ALLOCATOR
+#    define BOOST_NO_CXX11_POINTER_TRAITS
+#endif
+
+#if __cplusplus < 201103
+//
+// These two appear to be somewhat useable in C++03 mode, there may be others...
+//
+//#  define BOOST_NO_CXX11_HDR_ARRAY
+//#  define BOOST_NO_CXX11_HDR_FORWARD_LIST
+
+#  define BOOST_NO_CXX11_HDR_CODECVT
+#  define BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
+#  define BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#  define BOOST_NO_CXX11_HDR_MUTEX
+#  define BOOST_NO_CXX11_HDR_RANDOM
+#  define BOOST_NO_CXX11_HDR_RATIO
+#  define BOOST_NO_CXX11_HDR_REGEX
+#  define BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+#  define BOOST_NO_CXX11_HDR_THREAD
+#  define BOOST_NO_CXX11_HDR_TUPLE
+#  define BOOST_NO_CXX11_HDR_TYPEINDEX
+#  define BOOST_NO_CXX11_HDR_UNORDERED_MAP
+#  define BOOST_NO_CXX11_HDR_UNORDERED_SET
+#  define BOOST_NO_CXX11_NUMERIC_LIMITS
+#  define BOOST_NO_CXX11_ALLOCATOR
+#  define BOOST_NO_CXX11_POINTER_TRAITS
+#  define BOOST_NO_CXX11_SMART_PTR
+#  define BOOST_NO_CXX11_HDR_FUNCTIONAL
+#  define BOOST_NO_CXX11_STD_ALIGN
+#  define BOOST_NO_CXX11_ADDRESSOF
+#  define BOOST_NO_CXX11_HDR_ATOMIC
+#  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
+#  define BOOST_NO_CXX11_HDR_CHRONO
+#  define BOOST_NO_CXX11_HDR_TYPE_TRAITS
+#  define BOOST_NO_CXX11_HDR_FUTURE
+#elif _LIBCPP_VERSION < 3700
+//
+// These appear to be unusable/incomplete so far:
+//
+#  define BOOST_NO_CXX11_HDR_ATOMIC
+#  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
+#  define BOOST_NO_CXX11_HDR_CHRONO
+#  define BOOST_NO_CXX11_HDR_TYPE_TRAITS
+#  define BOOST_NO_CXX11_HDR_FUTURE
+#endif
+
+
+#if _LIBCPP_VERSION < 3700
+// libc++ uses a non-standard messages_base
+#define BOOST_NO_STD_MESSAGES
+#endif
+
+// C++14 features
+#if (_LIBCPP_VERSION < 3700) || (__cplusplus <= 201402L)
+#  define BOOST_NO_CXX14_STD_EXCHANGE
+#endif
+
+// C++17 features
+#if (_LIBCPP_VERSION < 3700) || (__cplusplus <= 201402L)
+#  define BOOST_NO_CXX17_STD_INVOKE
+#endif
+#if (_LIBCPP_VERSION < 4000) || (__cplusplus <= 201402L)
+#  define BOOST_NO_CXX17_STD_APPLY
+#endif
+#if (_LIBCPP_VERSION > 4000) && (__cplusplus > 201402L) && !defined(_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR)
+#  define BOOST_NO_AUTO_PTR
+#endif
+#if (_LIBCPP_VERSION > 4000) && (__cplusplus > 201402L) && !defined(_LIBCPP_ENABLE_CXX17_REMOVED_RANDOM_SHUFFLE)
+#  define BOOST_NO_CXX98_RANDOM_SHUFFLE
+#endif
+#if (_LIBCPP_VERSION > 4000) && (__cplusplus > 201402L) && !defined(_LIBCPP_ENABLE_CXX17_REMOVED_BINDERS)
+#  define BOOST_NO_CXX98_BINDERS
+#endif
+
+#define BOOST_NO_CXX17_ITERATOR_TRAITS
+
+#if (_LIBCPP_VERSION <= 1101) && !defined(BOOST_NO_CXX11_THREAD_LOCAL)
+// This is a bit of a sledgehammer, because really it's just libc++abi that has no
+// support for thread_local, leading to linker errors such as
+// "undefined reference to `__cxa_thread_atexit'".  It is fixed in the
+// most recent releases of libc++abi though...
+#  define BOOST_NO_CXX11_THREAD_LOCAL
+#endif
+
+#if defined(__linux__) && !defined(BOOST_NO_CXX11_THREAD_LOCAL)
+// After libc++-dev is installed on Trusty, clang++-libc++ almost works,
+// except uses of `thread_local` fail with undefined reference to
+// `__cxa_thread_atexit`.
+#  define BOOST_NO_CXX11_THREAD_LOCAL
+#endif
+
+#if defined(__has_include)
+#if !__has_include(<shared_mutex>)
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#elif __cplusplus <= 201103
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#endif
+#elif __cplusplus < 201402
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#endif
+
+//  --- end ---

--- a/src/boost/config/stdlib/libstdcpp3.hpp
+++ b/src/boost/config/stdlib/libstdcpp3.hpp
@@ -1,0 +1,349 @@
+//  (C) Copyright John Maddock 2001.
+//  (C) Copyright Jens Maurer 2001.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org for most recent version.
+
+//  config for libstdc++ v3
+//  not much to go in here:
+
+#define BOOST_GNU_STDLIB 1
+
+#ifdef __GLIBCXX__
+#define BOOST_STDLIB "GNU libstdc++ version " BOOST_STRINGIZE(__GLIBCXX__)
+#else
+#define BOOST_STDLIB "GNU libstdc++ version " BOOST_STRINGIZE(__GLIBCPP__)
+#endif
+
+#if !defined(_GLIBCPP_USE_WCHAR_T) && !defined(_GLIBCXX_USE_WCHAR_T)
+#  define BOOST_NO_CWCHAR
+#  define BOOST_NO_CWCTYPE
+#  define BOOST_NO_STD_WSTRING
+#  define BOOST_NO_STD_WSTREAMBUF
+#endif
+
+#if defined(__osf__) && !defined(_REENTRANT) \
+  && ( defined(_GLIBCXX_HAVE_GTHR_DEFAULT) || defined(_GLIBCPP_HAVE_GTHR_DEFAULT) )
+// GCC 3 on Tru64 forces the definition of _REENTRANT when any std lib header
+// file is included, therefore for consistency we define it here as well.
+#  define _REENTRANT
+#endif
+
+#ifdef __GLIBCXX__ // gcc 3.4 and greater:
+#  if defined(_GLIBCXX_HAVE_GTHR_DEFAULT) \
+        || defined(_GLIBCXX__PTHREADS) \
+        || defined(_GLIBCXX_HAS_GTHREADS) \
+        || defined(_WIN32) \
+        || defined(_AIX) \
+        || defined(__HAIKU__)
+      //
+      // If the std lib has thread support turned on, then turn it on in Boost
+      // as well.  We do this because some gcc-3.4 std lib headers define _REENTANT
+      // while others do not...
+      //
+#     define BOOST_HAS_THREADS
+#  else
+#     define BOOST_DISABLE_THREADS
+#  endif
+#elif defined(__GLIBCPP__) \
+        && !defined(_GLIBCPP_HAVE_GTHR_DEFAULT) \
+        && !defined(_GLIBCPP__PTHREADS)
+   // disable thread support if the std lib was built single threaded:
+#  define BOOST_DISABLE_THREADS
+#endif
+
+#if (defined(linux) || defined(__linux) || defined(__linux__)) && defined(__arm__) && defined(_GLIBCPP_HAVE_GTHR_DEFAULT)
+// linux on arm apparently doesn't define _REENTRANT
+// so just turn on threading support whenever the std lib is thread safe:
+#  define BOOST_HAS_THREADS
+#endif
+
+#if !defined(_GLIBCPP_USE_LONG_LONG) \
+    && !defined(_GLIBCXX_USE_LONG_LONG)\
+    && defined(BOOST_HAS_LONG_LONG)
+// May have been set by compiler/*.hpp, but "long long" without library
+// support is useless.
+#  undef BOOST_HAS_LONG_LONG
+#endif
+
+// Apple doesn't seem to reliably defined a *unix* macro
+#if !defined(CYGWIN) && (  defined(__unix__)  \
+                        || defined(__unix)    \
+                        || defined(unix)      \
+                        || defined(__APPLE__) \
+                        || defined(__APPLE)   \
+                        || defined(APPLE))
+#  include <unistd.h>
+#endif
+
+#ifndef __VXWORKS__ // VxWorks uses Dinkum, not GNU STL with GCC 
+#if defined(__GLIBCXX__) || (defined(__GLIBCPP__) && __GLIBCPP__>=20020514) // GCC >= 3.1.0
+#  define BOOST_STD_EXTENSION_NAMESPACE __gnu_cxx
+#  define BOOST_HAS_SLIST
+#  define BOOST_HAS_HASH
+#  define BOOST_SLIST_HEADER <ext/slist>
+# if !defined(__GNUC__) || __GNUC__ < 4 || (__GNUC__ == 4 && __GNUC_MINOR__ < 3)
+#   define BOOST_HASH_SET_HEADER <ext/hash_set>
+#   define BOOST_HASH_MAP_HEADER <ext/hash_map>
+# else
+#   define BOOST_HASH_SET_HEADER <backward/hash_set>
+#   define BOOST_HASH_MAP_HEADER <backward/hash_map>
+# endif
+#endif
+#endif
+
+//
+// Decide whether we have C++11 support turned on:
+//
+#if defined(__GXX_EXPERIMENTAL_CXX0X__) || (__cplusplus >= 201103)
+#  define BOOST_LIBSTDCXX11
+#endif
+
+//
+//  Decide which version of libstdc++ we have, normally
+//  libstdc++ C++0x support is detected via __GNUC__, __GNUC_MINOR__, and possibly
+//  __GNUC_PATCHLEVEL__ at the suggestion of Jonathan Wakely, one of the libstdc++
+//  developers. He also commented:
+//
+//       "I'm not sure how useful __GLIBCXX__ is for your purposes, for instance in
+//       GCC 4.2.4 it is set to 20080519 but in GCC 4.3.0 it is set to 20080305.
+//       Although 4.3.0 was released earlier than 4.2.4, it has better C++0x support
+//       than any release in the 4.2 series."
+//
+//  Another resource for understanding libstdc++ features is:
+//  http://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#manual.intro.status.standard.200x
+//
+//  However, using the GCC version number fails when the compiler is clang since this
+//  only ever claims to emulate GCC-4.2, see https://svn.boost.org/trac/boost/ticket/7473
+//  for a long discussion on this issue.  What we can do though is use clang's __has_include
+//  to detect the presence of a C++11 header that was introduced with a specific GCC release.
+//  We still have to be careful though as many such headers were buggy and/or incomplete when
+//  first introduced, so we only check for headers that were fully featured from day 1, and then
+//  use that to infer the underlying GCC version:
+//
+#ifdef __clang__
+
+#if __has_include(<experimental/memory_resource>)
+#  define BOOST_LIBSTDCXX_VERSION 60100
+#elif __has_include(<experimental/any>)
+#  define BOOST_LIBSTDCXX_VERSION 50100
+#elif __has_include(<shared_mutex>)
+#  define BOOST_LIBSTDCXX_VERSION 40900
+#elif __has_include(<ext/cmath>)
+#  define BOOST_LIBSTDCXX_VERSION 40800
+#elif __has_include(<scoped_allocator>)
+#  define BOOST_LIBSTDCXX_VERSION 40700
+#elif __has_include(<typeindex>)
+#  define BOOST_LIBSTDCXX_VERSION 40600
+#elif __has_include(<future>)
+#  define BOOST_LIBSTDCXX_VERSION 40500
+#elif  __has_include(<ratio>)
+#  define BOOST_LIBSTDCXX_VERSION 40400
+#elif __has_include(<array>)
+#  define BOOST_LIBSTDCXX_VERSION 40300
+#endif
+
+#if (BOOST_LIBSTDCXX_VERSION < 50100)
+// libstdc++ does not define this function as it's deprecated in C++11, but clang still looks for it,
+// defining it here is a terrible cludge, but should get things working:
+extern "C" char *gets (char *__s);
+#endif
+//
+// clang is unable to parse some GCC headers, add those workarounds here:
+//
+#if BOOST_LIBSTDCXX_VERSION < 50000
+#  define BOOST_NO_CXX11_HDR_REGEX
+#endif
+//
+// GCC 4.7.x has no __cxa_thread_atexit which
+// thread_local objects require for cleanup:
+//
+#if BOOST_LIBSTDCXX_VERSION < 40800
+#  define BOOST_NO_CXX11_THREAD_LOCAL
+#endif
+//
+// Early clang versions can handle <chrono>, not exactly sure which versions
+// but certainly up to clang-3.8 and gcc-4.6:
+//
+#if (__clang_major__ < 5)
+#  if BOOST_LIBSTDCXX_VERSION < 40800
+#     define BOOST_NO_CXX11_HDR_FUTURE
+#     define BOOST_NO_CXX11_HDR_MUTEX
+#     define BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
+#     define BOOST_NO_CXX11_HDR_CHRONO
+#  endif
+#endif
+
+//
+//  GCC 4.8 and 9 add working versions of <atomic> and <regex> respectively.
+//  However, we have no test for these as the headers were present but broken
+//  in early GCC versions.
+//
+#endif
+
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC >= 0x5130) && (__cplusplus >= 201103L)
+//
+// Oracle Solaris compiler uses it's own verison of libstdc++ but doesn't 
+// set __GNUC__
+//
+#if __SUNPRO_CC >= 0x5140
+#define BOOST_LIBSTDCXX_VERSION 50100
+#else
+#define BOOST_LIBSTDCXX_VERSION 40800
+#endif
+#endif
+
+#if !defined(BOOST_LIBSTDCXX_VERSION)
+#  define BOOST_LIBSTDCXX_VERSION (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+#endif
+
+// std::auto_ptr isn't provided with _GLIBCXX_DEPRECATED=0 (GCC 4.5 and earlier)
+// or _GLIBCXX_USE_DEPRECATED=0 (GCC 4.6 and later).
+#if defined(BOOST_LIBSTDCXX11)
+#  if BOOST_LIBSTDCXX_VERSION < 40600
+#     if !_GLIBCXX_DEPRECATED
+#        define BOOST_NO_AUTO_PTR
+#     endif
+#  elif !_GLIBCXX_USE_DEPRECATED
+#     define BOOST_NO_AUTO_PTR
+#  endif
+#endif
+
+//  C++0x headers in GCC 4.3.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40300) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX11_HDR_ARRAY
+#  define BOOST_NO_CXX11_HDR_TUPLE
+#  define BOOST_NO_CXX11_HDR_UNORDERED_MAP
+#  define BOOST_NO_CXX11_HDR_UNORDERED_SET
+#  define BOOST_NO_CXX11_HDR_FUNCTIONAL
+#endif
+
+//  C++0x headers in GCC 4.4.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40400) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
+#  define BOOST_NO_CXX11_HDR_FORWARD_LIST
+#  define BOOST_NO_CXX11_HDR_INITIALIZER_LIST
+#  define BOOST_NO_CXX11_HDR_MUTEX
+#  define BOOST_NO_CXX11_HDR_RATIO
+#  define BOOST_NO_CXX11_HDR_SYSTEM_ERROR
+#  define BOOST_NO_CXX11_SMART_PTR
+#else
+#  define BOOST_HAS_TR1_COMPLEX_INVERSE_TRIG 
+#  define BOOST_HAS_TR1_COMPLEX_OVERLOADS 
+#endif
+
+//  C++0x features in GCC 4.5.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40500) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX11_NUMERIC_LIMITS
+#  define BOOST_NO_CXX11_HDR_FUTURE
+#  define BOOST_NO_CXX11_HDR_RANDOM
+#endif
+
+//  C++0x features in GCC 4.6.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40600) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX11_HDR_TYPEINDEX
+#  define BOOST_NO_CXX11_ADDRESSOF
+#  define BOOST_NO_CXX17_ITERATOR_TRAITS
+#endif
+
+//  C++0x features in GCC 4.7.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40700) || !defined(BOOST_LIBSTDCXX11)
+// Note that although <chrono> existed prior to 4.7, "steady_clock" is spelled "monotonic_clock"
+// so 4.7.0 is the first truly conforming one.
+#  define BOOST_NO_CXX11_HDR_CHRONO
+#  define BOOST_NO_CXX11_ALLOCATOR
+#  define BOOST_NO_CXX11_POINTER_TRAITS
+#endif
+//  C++0x features in GCC 4.8.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40800) || !defined(BOOST_LIBSTDCXX11)
+// Note that although <atomic> existed prior to gcc 4.8 it was largely unimplemented for many types:
+#  define BOOST_NO_CXX11_HDR_ATOMIC
+#  define BOOST_NO_CXX11_HDR_THREAD
+#endif
+//  C++0x features in GCC 4.9.0 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 40900) || !defined(BOOST_LIBSTDCXX11)
+// Although <regex> is present and compilable against, the actual implementation is not functional
+// even for the simplest patterns such as "\d" or "[0-9]". This is the case at least in gcc up to 4.8, inclusively.
+#  define BOOST_NO_CXX11_HDR_REGEX
+#endif
+#if (BOOST_LIBSTDCXX_VERSION < 40900) || (__cplusplus <= 201103)
+#  define BOOST_NO_CXX14_STD_EXCHANGE
+#endif
+
+#if defined(__clang_major__) && ((__clang_major__ < 3) || ((__clang_major__ == 3) && (__clang_minor__ < 7)))
+// As of clang-3.6, libstdc++ header <atomic> throws up errors with clang:
+#  define BOOST_NO_CXX11_HDR_ATOMIC
+#endif
+//
+//  C++0x features in GCC 5.1 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 50100) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX11_HDR_TYPE_TRAITS
+#  define BOOST_NO_CXX11_HDR_CODECVT
+#  define BOOST_NO_CXX11_ATOMIC_SMART_PTR
+#  define BOOST_NO_CXX11_STD_ALIGN
+#endif
+
+//
+//  C++17 features in GCC 6.1 and later
+//
+#if (BOOST_LIBSTDCXX_VERSION < 60100) || (__cplusplus <= 201402L)
+#  define BOOST_NO_CXX17_STD_INVOKE
+#endif
+#if (BOOST_LIBSTDCXX_VERSION < 70100) || (__cplusplus <= 201402L)
+#  define BOOST_NO_CXX17_STD_APPLY
+#endif
+
+#if defined(__has_include)
+#if !__has_include(<shared_mutex>)
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#elif __cplusplus <= 201103
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#endif
+#elif __cplusplus < 201402 || (BOOST_LIBSTDCXX_VERSION < 40900) || !defined(BOOST_LIBSTDCXX11)
+#  define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#endif
+
+//
+// Headers not present on Solaris with the Oracle compiler:
+#if defined(__SUNPRO_CC) && (__SUNPRO_CC < 0x5140)
+#define BOOST_NO_CXX11_HDR_FUTURE
+#define BOOST_NO_CXX11_HDR_FORWARD_LIST 
+#define BOOST_NO_CXX11_HDR_ATOMIC
+// shared_ptr is present, but is not convertible to bool
+// which causes all kinds of problems especially in Boost.Thread
+// but probably elsewhere as well.
+#define BOOST_NO_CXX11_SMART_PTR
+#endif
+
+#if (!defined(_GLIBCXX_HAS_GTHREADS) || !defined(_GLIBCXX_USE_C99_STDINT_TR1))
+   // Headers not always available:
+#  ifndef BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
+#     define BOOST_NO_CXX11_HDR_CONDITION_VARIABLE
+#  endif
+#  ifndef BOOST_NO_CXX11_HDR_MUTEX
+#     define BOOST_NO_CXX11_HDR_MUTEX
+#  endif
+#  ifndef BOOST_NO_CXX11_HDR_THREAD
+#     define BOOST_NO_CXX11_HDR_THREAD
+#  endif
+#  ifndef BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#     define BOOST_NO_CXX14_HDR_SHARED_MUTEX
+#  endif
+#endif
+
+#if (!defined(_GTHREAD_USE_MUTEX_TIMEDLOCK) || (_GTHREAD_USE_MUTEX_TIMEDLOCK == 0)) && !defined(BOOST_NO_CXX11_HDR_MUTEX)
+// Timed mutexes are not always available:
+#  define BOOST_NO_CXX11_HDR_MUTEX
+#endif
+
+//  --- end ---

--- a/src/boost/config/user.hpp
+++ b/src/boost/config/user.hpp
@@ -1,0 +1,133 @@
+//  boost/config/user.hpp  ---------------------------------------------------//
+
+//  (C) Copyright John Maddock 2001. 
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  Do not check in modified versions of this file,
+//  This file may be customized by the end user, but not by boost.
+
+//
+//  Use this file to define a site and compiler specific
+//  configuration policy:
+//
+
+// define this to locate a compiler config file:
+// #define BOOST_COMPILER_CONFIG <myheader>
+
+// define this to locate a stdlib config file:
+// #define BOOST_STDLIB_CONFIG   <myheader>
+
+// define this to locate a platform config file:
+// #define BOOST_PLATFORM_CONFIG <myheader>
+
+// define this to disable compiler config,
+// use if your compiler config has nothing to set:
+// #define BOOST_NO_COMPILER_CONFIG
+
+// define this to disable stdlib config,
+// use if your stdlib config has nothing to set:
+// #define BOOST_NO_STDLIB_CONFIG
+
+// define this to disable platform config,
+// use if your platform config has nothing to set:
+// #define BOOST_NO_PLATFORM_CONFIG
+
+// define this to disable all config options,
+// excluding the user config.  Use if your
+// setup is fully ISO compliant, and has no
+// useful extensions, or for autoconf generated
+// setups:
+// #define BOOST_NO_CONFIG
+
+// define this to make the config "optimistic"
+// about unknown compiler versions.  Normally
+// unknown compiler versions are assumed to have
+// all the defects of the last known version, however
+// setting this flag, causes the config to assume
+// that unknown compiler versions are fully conformant
+// with the standard:
+// #define BOOST_STRICT_CONFIG
+
+// define this to cause the config to halt compilation
+// with an #error if it encounters anything unknown --
+// either an unknown compiler version or an unknown
+// compiler/platform/library:
+// #define BOOST_ASSERT_CONFIG
+
+
+// define if you want to disable threading support, even
+// when available:
+// #define BOOST_DISABLE_THREADS
+
+// define when you want to disable Win32 specific features
+// even when available:
+// #define BOOST_DISABLE_WIN32
+
+// BOOST_DISABLE_ABI_HEADERS: Stops boost headers from including any 
+// prefix/suffix headers that normally control things like struct 
+// packing and alignment. 
+// #define BOOST_DISABLE_ABI_HEADERS
+
+// BOOST_ABI_PREFIX: A prefix header to include in place of whatever
+// boost.config would normally select, any replacement should set up 
+// struct packing and alignment options as required. 
+// #define BOOST_ABI_PREFIX my-header-name
+
+// BOOST_ABI_SUFFIX: A suffix header to include in place of whatever 
+// boost.config would normally select, any replacement should undo 
+// the effects of the prefix header. 
+// #define BOOST_ABI_SUFFIX my-header-name
+
+// BOOST_ALL_DYN_LINK: Forces all libraries that have separate source, 
+// to be linked as dll's rather than static libraries on Microsoft Windows 
+// (this macro is used to turn on __declspec(dllimport) modifiers, so that 
+// the compiler knows which symbols to look for in a dll rather than in a 
+// static library).  Note that there may be some libraries that can only 
+// be linked in one way (statically or dynamically), in these cases this 
+// macro has no effect.
+// #define BOOST_ALL_DYN_LINK
+ 
+// BOOST_WHATEVER_DYN_LINK: Forces library "whatever" to be linked as a dll 
+// rather than a static library on Microsoft Windows: replace the WHATEVER 
+// part of the macro name with the name of the library that you want to 
+// dynamically link to, for example use BOOST_DATE_TIME_DYN_LINK or 
+// BOOST_REGEX_DYN_LINK etc (this macro is used to turn on __declspec(dllimport) 
+// modifiers, so that the compiler knows which symbols to look for in a dll 
+// rather than in a static library).  
+// Note that there may be some libraries that can only 
+// be linked in one way (statically or dynamically), 
+// in these cases this macro is unsupported.
+// #define BOOST_WHATEVER_DYN_LINK
+ 
+// BOOST_ALL_NO_LIB: Tells the config system not to automatically select 
+// which libraries to link against.  
+// Normally if a compiler supports #pragma lib, then the correct library 
+// build variant will be automatically selected and linked against, 
+// simply by the act of including one of that library's headers.  
+// This macro turns that feature off.
+// #define BOOST_ALL_NO_LIB
+ 
+// BOOST_WHATEVER_NO_LIB: Tells the config system not to automatically 
+// select which library to link against for library "whatever", 
+// replace WHATEVER in the macro name with the name of the library; 
+// for example BOOST_DATE_TIME_NO_LIB or BOOST_REGEX_NO_LIB.  
+// Normally if a compiler supports #pragma lib, then the correct library 
+// build variant will be automatically selected and linked against, simply 
+// by the act of including one of that library's headers.  This macro turns 
+// that feature off.
+// #define BOOST_WHATEVER_NO_LIB
+ 
+// BOOST_LIB_BUILDID: Set to the same value as the value passed to Boost.Build's
+// --buildid command line option.  For example if you built using:
+//
+// bjam address-model=64 --buildid=amd64
+//
+// then compile your code with:
+//
+// -DBOOST_LIB_BUILDID = amd64
+//
+// to ensure the correct libraries are selected at link time.
+// #define BOOST_LIB_BUILDID amd64
+

--- a/src/boost/config/workaround.hpp
+++ b/src/boost/config/workaround.hpp
@@ -1,0 +1,279 @@
+// Copyright David Abrahams 2002.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#ifndef BOOST_CONFIG_WORKAROUND_HPP
+#define BOOST_CONFIG_WORKAROUND_HPP
+
+// Compiler/library version workaround macro
+//
+// Usage:
+//
+//   #if BOOST_WORKAROUND(BOOST_MSVC, < 1300)
+//      // workaround for eVC4 and VC6
+//      ... // workaround code here
+//   #endif
+//
+// When BOOST_STRICT_CONFIG is defined, expands to 0. Otherwise, the
+// first argument must be undefined or expand to a numeric
+// value. The above expands to:
+//
+//   (BOOST_MSVC) != 0 && (BOOST_MSVC) < 1300
+//
+// When used for workarounds that apply to the latest known version
+// and all earlier versions of a compiler, the following convention
+// should be observed:
+//
+//   #if BOOST_WORKAROUND(BOOST_MSVC, BOOST_TESTED_AT(1301))
+//
+// The version number in this case corresponds to the last version in
+// which the workaround was known to have been required. When
+// BOOST_DETECT_OUTDATED_WORKAROUNDS is not the defined, the macro
+// BOOST_TESTED_AT(x) expands to "!= 0", which effectively activates
+// the workaround for any version of the compiler. When
+// BOOST_DETECT_OUTDATED_WORKAROUNDS is defined, a compiler warning or
+// error will be issued if the compiler version exceeds the argument
+// to BOOST_TESTED_AT().  This can be used to locate workarounds which
+// may be obsoleted by newer versions.
+
+#ifndef BOOST_STRICT_CONFIG
+
+#include <boost/config.hpp>
+
+#ifndef __BORLANDC__
+#define __BORLANDC___WORKAROUND_GUARD 1
+#else
+#define __BORLANDC___WORKAROUND_GUARD 0
+#endif
+#ifndef __CODEGEARC__
+#define __CODEGEARC___WORKAROUND_GUARD 1
+#else
+#define __CODEGEARC___WORKAROUND_GUARD 0
+#endif
+#ifndef _MSC_VER
+#define _MSC_VER_WORKAROUND_GUARD 1
+#else
+#define _MSC_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef _MSC_FULL_VER
+#define _MSC_FULL_VER_WORKAROUND_GUARD 1
+#else
+#define _MSC_FULL_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_MSVC
+#define BOOST_MSVC_WORKAROUND_GUARD 1
+#else
+#define BOOST_MSVC_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_MSVC_FULL_VER
+#define BOOST_MSVC_FULL_VER_WORKAROUND_GUARD 1
+#else
+#define BOOST_MSVC_FULL_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef __GNUC__
+#define __GNUC___WORKAROUND_GUARD 1
+#else
+#define __GNUC___WORKAROUND_GUARD 0
+#endif
+#ifndef __GNUC_MINOR__
+#define __GNUC_MINOR___WORKAROUND_GUARD 1
+#else
+#define __GNUC_MINOR___WORKAROUND_GUARD 0
+#endif
+#ifndef __GNUC_PATCHLEVEL__
+#define __GNUC_PATCHLEVEL___WORKAROUND_GUARD 1
+#else
+#define __GNUC_PATCHLEVEL___WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_GCC
+#define BOOST_GCC_WORKAROUND_GUARD 1
+#define BOOST_GCC_VERSION_WORKAROUND_GUARD 1
+#else
+#define BOOST_GCC_WORKAROUND_GUARD 0
+#define BOOST_GCC_VERSION_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_XLCPP_ZOS
+#define BOOST_XLCPP_ZOS_WORKAROUND_GUARD 1
+#else
+#define BOOST_XLCPP_ZOS_WORKAROUND_GUARD 0
+#endif
+#ifndef __IBMCPP__
+#define __IBMCPP___WORKAROUND_GUARD 1
+#else
+#define __IBMCPP___WORKAROUND_GUARD 0
+#endif
+#ifndef __SUNPRO_CC
+#define __SUNPRO_CC_WORKAROUND_GUARD 1
+#else
+#define __SUNPRO_CC_WORKAROUND_GUARD 0
+#endif
+#ifndef __DECCXX_VER
+#define __DECCXX_VER_WORKAROUND_GUARD 1
+#else
+#define __DECCXX_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef __MWERKS__
+#define __MWERKS___WORKAROUND_GUARD 1
+#else
+#define __MWERKS___WORKAROUND_GUARD 0
+#endif
+#ifndef __EDG__
+#define __EDG___WORKAROUND_GUARD 1
+#else
+#define __EDG___WORKAROUND_GUARD 0
+#endif
+#ifndef __EDG_VERSION__
+#define __EDG_VERSION___WORKAROUND_GUARD 1
+#else
+#define __EDG_VERSION___WORKAROUND_GUARD 0
+#endif
+#ifndef __HP_aCC
+#define __HP_aCC_WORKAROUND_GUARD 1
+#else
+#define __HP_aCC_WORKAROUND_GUARD 0
+#endif
+#ifndef __hpxstd98
+#define __hpxstd98_WORKAROUND_GUARD 1
+#else
+#define __hpxstd98_WORKAROUND_GUARD 0
+#endif
+#ifndef _CRAYC
+#define _CRAYC_WORKAROUND_GUARD 1
+#else
+#define _CRAYC_WORKAROUND_GUARD 0
+#endif
+#ifndef __DMC__
+#define __DMC___WORKAROUND_GUARD 1
+#else
+#define __DMC___WORKAROUND_GUARD 0
+#endif
+#ifndef MPW_CPLUS
+#define MPW_CPLUS_WORKAROUND_GUARD 1
+#else
+#define MPW_CPLUS_WORKAROUND_GUARD 0
+#endif
+#ifndef __COMO__
+#define __COMO___WORKAROUND_GUARD 1
+#else
+#define __COMO___WORKAROUND_GUARD 0
+#endif
+#ifndef __COMO_VERSION__
+#define __COMO_VERSION___WORKAROUND_GUARD 1
+#else
+#define __COMO_VERSION___WORKAROUND_GUARD 0
+#endif
+#ifndef __INTEL_COMPILER
+#define __INTEL_COMPILER_WORKAROUND_GUARD 1
+#else
+#define __INTEL_COMPILER_WORKAROUND_GUARD 0
+#endif
+#ifndef __ICL
+#define __ICL_WORKAROUND_GUARD 1
+#else
+#define __ICL_WORKAROUND_GUARD 0
+#endif
+#ifndef _COMPILER_VERSION
+#define _COMPILER_VERSION_WORKAROUND_GUARD 1
+#else
+#define _COMPILER_VERSION_WORKAROUND_GUARD 0
+#endif
+
+#ifndef _RWSTD_VER
+#define _RWSTD_VER_WORKAROUND_GUARD 1
+#else
+#define _RWSTD_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_RWSTD_VER
+#define BOOST_RWSTD_VER_WORKAROUND_GUARD 1
+#else
+#define BOOST_RWSTD_VER_WORKAROUND_GUARD 0
+#endif
+#ifndef __GLIBCPP__
+#define __GLIBCPP___WORKAROUND_GUARD 1
+#else
+#define __GLIBCPP___WORKAROUND_GUARD 0
+#endif
+#ifndef _GLIBCXX_USE_C99_FP_MACROS_DYNAMIC
+#define _GLIBCXX_USE_C99_FP_MACROS_DYNAMIC_WORKAROUND_GUARD 1
+#else
+#define _GLIBCXX_USE_C99_FP_MACROS_DYNAMIC_WORKAROUND_GUARD 0
+#endif
+#ifndef __SGI_STL_PORT
+#define __SGI_STL_PORT_WORKAROUND_GUARD 1
+#else
+#define __SGI_STL_PORT_WORKAROUND_GUARD 0
+#endif
+#ifndef _STLPORT_VERSION
+#define _STLPORT_VERSION_WORKAROUND_GUARD 1
+#else
+#define _STLPORT_VERSION_WORKAROUND_GUARD 0
+#endif
+#ifndef __LIBCOMO_VERSION__
+#define __LIBCOMO_VERSION___WORKAROUND_GUARD 1
+#else
+#define __LIBCOMO_VERSION___WORKAROUND_GUARD 0
+#endif
+#ifndef _CPPLIB_VER
+#define _CPPLIB_VER_WORKAROUND_GUARD 1
+#else
+#define _CPPLIB_VER_WORKAROUND_GUARD 0
+#endif
+
+#ifndef BOOST_INTEL_CXX_VERSION
+#define BOOST_INTEL_CXX_VERSION_WORKAROUND_GUARD 1
+#else
+#define BOOST_INTEL_CXX_VERSION_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_INTEL_WIN
+#define BOOST_INTEL_WIN_WORKAROUND_GUARD 1
+#else
+#define BOOST_INTEL_WIN_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_DINKUMWARE_STDLIB
+#define BOOST_DINKUMWARE_STDLIB_WORKAROUND_GUARD 1
+#else
+#define BOOST_DINKUMWARE_STDLIB_WORKAROUND_GUARD 0
+#endif
+#ifndef BOOST_INTEL
+#define BOOST_INTEL_WORKAROUND_GUARD 1
+#else
+#define BOOST_INTEL_WORKAROUND_GUARD 0
+#endif
+// Always define to zero, if it's used it'll be defined my MPL:
+#define BOOST_MPL_CFG_GCC_WORKAROUND_GUARD 0
+
+#define BOOST_WORKAROUND(symbol, test)                \
+       ((symbol ## _WORKAROUND_GUARD + 0 == 0) &&     \
+       (symbol != 0) && (1 % (( (symbol test) ) + 1)))
+//                              ^ ^           ^ ^
+// The extra level of parenthesis nesting above, along with the
+// BOOST_OPEN_PAREN indirection below, is required to satisfy the
+// broken preprocessor in MWCW 8.3 and earlier.
+//
+// The basic mechanism works as follows:
+//   (symbol test) + 1        =>   if (symbol test) then 2 else 1
+//   1 % ((symbol test) + 1)  =>   if (symbol test) then 1 else 0
+//
+// The complication with % is for cooperation with BOOST_TESTED_AT().
+// When "test" is BOOST_TESTED_AT(x) and
+// BOOST_DETECT_OUTDATED_WORKAROUNDS is #defined,
+//
+//   symbol test              =>   if (symbol <= x) then 1 else -1
+//   (symbol test) + 1        =>   if (symbol <= x) then 2 else 0
+//   1 % ((symbol test) + 1)  =>   if (symbol <= x) then 1 else divide-by-zero
+//
+
+#ifdef BOOST_DETECT_OUTDATED_WORKAROUNDS
+#  define BOOST_OPEN_PAREN (
+#  define BOOST_TESTED_AT(value)  > value) ?(-1): BOOST_OPEN_PAREN 1
+#else
+#  define BOOST_TESTED_AT(value) != ((value)-(value))
+#endif
+
+#else
+
+#define BOOST_WORKAROUND(symbol, test) 0
+
+#endif
+
+#endif // BOOST_CONFIG_WORKAROUND_HPP

--- a/src/boost/core/addressof.hpp
+++ b/src/boost/core/addressof.hpp
@@ -1,0 +1,274 @@
+/*
+Copyright (C) 2002 Brad King (brad.king@kitware.com)
+                   Douglas Gregor (gregod@cs.rpi.edu)
+
+Copyright (C) 2002, 2008, 2013 Peter Dimov
+
+Copyright (C) 2017 Glen Joseph Fernandes (glenjofe@gmail.com)
+
+Distributed under the Boost Software License, Version 1.0.
+(See accompanying file LICENSE_1_0.txt or copy at
+http://www.boost.org/LICENSE_1_0.txt)
+*/
+
+#ifndef BOOST_CORE_ADDRESSOF_HPP
+#define BOOST_CORE_ADDRESSOF_HPP
+
+#include <boost/config.hpp>
+
+#if defined(BOOST_MSVC_FULL_VER) && BOOST_MSVC_FULL_VER >= 190024215
+#define BOOST_CORE_HAS_BUILTIN_ADDRESSOF
+#elif defined(BOOST_GCC) && BOOST_GCC >= 70000
+#define BOOST_CORE_HAS_BUILTIN_ADDRESSOF
+#elif defined(__has_builtin)
+#if __has_builtin(__builtin_addressof)
+#define BOOST_CORE_HAS_BUILTIN_ADDRESSOF
+#endif
+#endif
+
+#if defined(BOOST_CORE_HAS_BUILTIN_ADDRESSOF)
+#if defined(BOOST_NO_CXX11_CONSTEXPR)
+#define BOOST_CORE_NO_CONSTEXPR_ADDRESSOF
+#endif
+
+namespace boost {
+
+template<class T>
+BOOST_CONSTEXPR inline T*
+addressof(T& o) BOOST_NOEXCEPT
+{
+    return __builtin_addressof(o);
+}
+
+} /* boost */
+#else
+#include <boost/config/workaround.hpp>
+#include <cstddef>
+
+namespace boost {
+namespace detail {
+
+template<class T>
+class addrof_ref {
+public:
+    BOOST_FORCEINLINE addrof_ref(T& o) BOOST_NOEXCEPT
+        : o_(o) { }
+    BOOST_FORCEINLINE operator T&() const BOOST_NOEXCEPT {
+        return o_;
+    }
+private:
+    addrof_ref& operator=(const addrof_ref&);
+    T& o_;
+};
+
+template<class T>
+struct addrof {
+    static BOOST_FORCEINLINE T* get(T& o, long) BOOST_NOEXCEPT {
+        return reinterpret_cast<T*>(&
+            const_cast<char&>(reinterpret_cast<const volatile char&>(o)));
+    }
+    static BOOST_FORCEINLINE T* get(T* p, int) BOOST_NOEXCEPT {
+        return p;
+    }
+};
+
+#if !defined(BOOST_NO_CXX11_NULLPTR)
+#if !defined(BOOST_NO_CXX11_DECLTYPE) && \
+    (defined(__INTEL_COMPILER) || \
+        (defined(__clang__) && !defined(_LIBCPP_VERSION)))
+typedef decltype(nullptr) addrof_null_t;
+#else
+typedef std::nullptr_t addrof_null_t;
+#endif
+
+template<>
+struct addrof<addrof_null_t> {
+    typedef addrof_null_t type;
+    static BOOST_FORCEINLINE type* get(type& o, int) BOOST_NOEXCEPT {
+        return &o;
+    }
+};
+
+template<>
+struct addrof<const addrof_null_t> {
+    typedef const addrof_null_t type;
+    static BOOST_FORCEINLINE type* get(type& o, int) BOOST_NOEXCEPT {
+        return &o;
+    }
+};
+
+template<>
+struct addrof<volatile addrof_null_t> {
+    typedef volatile addrof_null_t type;
+    static BOOST_FORCEINLINE type* get(type& o, int) BOOST_NOEXCEPT {
+        return &o;
+    }
+};
+
+template<>
+struct addrof<const volatile addrof_null_t> {
+    typedef const volatile addrof_null_t type;
+    static BOOST_FORCEINLINE type* get(type& o, int) BOOST_NOEXCEPT {
+        return &o;
+    }
+};
+#endif
+
+} /* detail */
+
+#if defined(BOOST_NO_CXX11_SFINAE_EXPR) || \
+    defined(BOOST_NO_CXX11_CONSTEXPR) || \
+    defined(BOOST_NO_CXX11_DECLTYPE)
+#define BOOST_CORE_NO_CONSTEXPR_ADDRESSOF
+
+template<class T>
+BOOST_FORCEINLINE T*
+addressof(T& o) BOOST_NOEXCEPT
+{
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x610)) || \
+    BOOST_WORKAROUND(__SUNPRO_CC, <= 0x5120)
+    return boost::detail::addrof<T>::get(o, 0);
+#else
+    return boost::detail::addrof<T>::get(boost::detail::addrof_ref<T>(o), 0);
+#endif
+}
+
+#if BOOST_WORKAROUND(__SUNPRO_CC, BOOST_TESTED_AT(0x590))
+namespace detail {
+
+template<class T>
+struct addrof_result {
+    typedef T* type;
+};
+
+} /* detail */
+
+template<class T, std::size_t N>
+BOOST_FORCEINLINE typename boost::detail::addrof_result<T[N]>::type
+addressof(T (&o)[N]) BOOST_NOEXCEPT
+{
+    return &o;
+}
+#endif
+
+#if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+template<class T, std::size_t N>
+BOOST_FORCEINLINE
+T (*addressof(T (&o)[N]) BOOST_NOEXCEPT)[N]
+{
+   return reinterpret_cast<T(*)[N]>(&o);
+}
+
+template<class T, std::size_t N>
+BOOST_FORCEINLINE
+const T (*addressof(const T (&o)[N]) BOOST_NOEXCEPT)[N]
+{
+   return reinterpret_cast<const T(*)[N]>(&o);
+}
+#endif
+#else
+namespace detail {
+
+template<class T>
+T addrof_declval() BOOST_NOEXCEPT;
+
+template<class>
+struct addrof_void {
+    typedef void type;
+};
+
+template<class T, class E = void>
+struct addrof_member_operator {
+    static constexpr bool value = false;
+};
+
+template<class T>
+struct addrof_member_operator<T, typename
+    addrof_void<decltype(addrof_declval<T&>().operator&())>::type> {
+    static constexpr bool value = true;
+};
+
+#if BOOST_WORKAROUND(BOOST_INTEL, < 1600)
+struct addrof_addressable { };
+
+addrof_addressable*
+operator&(addrof_addressable&) BOOST_NOEXCEPT;
+#endif
+
+template<class T, class E = void>
+struct addrof_non_member_operator {
+    static constexpr bool value = false;
+};
+
+template<class T>
+struct addrof_non_member_operator<T, typename
+    addrof_void<decltype(operator&(addrof_declval<T&>()))>::type> {
+    static constexpr bool value = true;
+};
+
+template<class T, class E = void>
+struct addrof_expression {
+    static constexpr bool value = false;
+};
+
+template<class T>
+struct addrof_expression<T,
+    typename addrof_void<decltype(&addrof_declval<T&>())>::type> {
+    static constexpr bool value = true;
+};
+
+template<class T>
+struct addrof_is_constexpr {
+    static constexpr bool value = addrof_expression<T>::value &&
+        !addrof_member_operator<T>::value &&
+        !addrof_non_member_operator<T>::value;
+};
+
+template<bool E, class T>
+struct addrof_if { };
+
+template<class T>
+struct addrof_if<true, T> {
+    typedef T* type;
+};
+
+template<class T>
+BOOST_FORCEINLINE
+typename addrof_if<!addrof_is_constexpr<T>::value, T>::type
+addressof(T& o) BOOST_NOEXCEPT
+{
+    return addrof<T>::get(addrof_ref<T>(o), 0);
+}
+
+template<class T>
+constexpr BOOST_FORCEINLINE
+typename addrof_if<addrof_is_constexpr<T>::value, T>::type
+addressof(T& o) BOOST_NOEXCEPT
+{
+    return &o;
+}
+
+} /* detail */
+
+template<class T>
+constexpr BOOST_FORCEINLINE T*
+addressof(T& o) BOOST_NOEXCEPT
+{
+    return boost::detail::addressof(o);
+}
+#endif
+
+} /* boost */
+#endif
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && \
+    !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS)
+namespace boost {
+
+template<class T>
+const T* addressof(const T&&) = delete;
+
+} /* boost */
+#endif
+
+#endif

--- a/src/boost/core/no_exceptions_support.hpp
+++ b/src/boost/core/no_exceptions_support.hpp
@@ -1,0 +1,44 @@
+#ifndef BOOST_CORE_NO_EXCEPTIONS_SUPPORT_HPP
+#define BOOST_CORE_NO_EXCEPTIONS_SUPPORT_HPP
+
+#if defined(_MSC_VER)
+#  pragma once
+#endif
+
+//----------------------------------------------------------------------
+// (C) Copyright 2004 Pavel Vozenilek.
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt
+// or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+//
+// This file contains helper macros used when exception support may be
+// disabled (as indicated by macro BOOST_NO_EXCEPTIONS).
+//
+// Before picking up these macros you may consider using RAII techniques
+// to deal with exceptions - their syntax can be always the same with 
+// or without exception support enabled.
+//----------------------------------------------------------------------
+
+#include <boost/config.hpp>
+#include <boost/config/workaround.hpp>
+
+#if !(defined BOOST_NO_EXCEPTIONS)
+#    define BOOST_TRY { try
+#    define BOOST_CATCH(x) catch(x)
+#    define BOOST_RETHROW throw;
+#    define BOOST_CATCH_END }
+#else
+#    if BOOST_WORKAROUND(__BORLANDC__, BOOST_TESTED_AT(0x564))
+#        define BOOST_TRY { if ("")
+#        define BOOST_CATCH(x) else if (!"")
+#    else
+#        define BOOST_TRY { if (true)
+#        define BOOST_CATCH(x) else if (false)
+#    endif
+#    define BOOST_RETHROW
+#    define BOOST_CATCH_END }
+#endif
+
+
+#endif 

--- a/src/boost/current_function.hpp
+++ b/src/boost/current_function.hpp
@@ -1,0 +1,75 @@
+#ifndef BOOST_CURRENT_FUNCTION_HPP_INCLUDED
+#define BOOST_CURRENT_FUNCTION_HPP_INCLUDED
+
+// MS compatible compilers support #pragma once
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
+
+//
+//  boost/current_function.hpp - BOOST_CURRENT_FUNCTION
+//
+//  Copyright (c) 2002 Peter Dimov and Multi Media Ltd.
+//
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt
+//
+//  http://www.boost.org/libs/assert/current_function.html
+//
+
+namespace boost
+{
+
+namespace detail
+{
+
+inline void current_function_helper()
+{
+
+#if defined( BOOST_DISABLE_CURRENT_FUNCTION )
+
+# define BOOST_CURRENT_FUNCTION "(unknown)"
+
+#elif defined(__GNUC__) || (defined(__MWERKS__) && (__MWERKS__ >= 0x3000)) || (defined(__ICC) && (__ICC >= 600)) || defined(__ghs__)
+
+# define BOOST_CURRENT_FUNCTION __PRETTY_FUNCTION__
+
+#elif defined(__DMC__) && (__DMC__ >= 0x810)
+
+# define BOOST_CURRENT_FUNCTION __PRETTY_FUNCTION__
+
+#elif defined(__FUNCSIG__)
+
+# define BOOST_CURRENT_FUNCTION __FUNCSIG__
+
+#elif (defined(__INTEL_COMPILER) && (__INTEL_COMPILER >= 600)) || (defined(__IBMCPP__) && (__IBMCPP__ >= 500))
+
+# define BOOST_CURRENT_FUNCTION __FUNCTION__
+
+#elif defined(__BORLANDC__) && (__BORLANDC__ >= 0x550)
+
+# define BOOST_CURRENT_FUNCTION __FUNC__
+
+#elif defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901)
+
+# define BOOST_CURRENT_FUNCTION __func__
+
+#elif defined(__cplusplus) && (__cplusplus >= 201103)
+
+# define BOOST_CURRENT_FUNCTION __func__
+
+#else
+
+# define BOOST_CURRENT_FUNCTION "(unknown)"
+
+#endif
+
+}
+
+} // namespace detail
+
+} // namespace boost
+
+#endif // #ifndef BOOST_CURRENT_FUNCTION_HPP_INCLUDED

--- a/src/boost/detail/iterator.hpp
+++ b/src/boost/detail/iterator.hpp
@@ -1,0 +1,39 @@
+// (C) Copyright David Abrahams 2002.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef ITERATOR_DWA122600_HPP_
+#define ITERATOR_DWA122600_HPP_
+
+// This header is obsolete and will be deprecated.
+
+#include <iterator>
+#if defined(__SUNPRO_CC) && (defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION))
+#include <cstddef>
+#endif
+
+namespace boost
+{
+
+namespace detail
+{
+
+using std::iterator_traits;
+using std::distance;
+
+#if defined(__SUNPRO_CC) && (defined(__SGI_STL_PORT) || defined(_STLPORT_VERSION))
+// std::distance from stlport with Oracle compiler 12.4 and 12.5 fails to deduce template parameters
+// when one of the arguments is an array and the other one is a pointer.
+template< typename T, std::size_t N >
+inline typename std::iterator_traits< T* >::difference_type distance(T (&left)[N], T* right)
+{
+    return std::distance(static_cast< T* >(left), right);
+}
+#endif
+
+} // namespace detail
+
+} // namespace boost
+
+#endif // ITERATOR_DWA122600_HPP_

--- a/src/boost/detail/no_exceptions_support.hpp
+++ b/src/boost/detail/no_exceptions_support.hpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2014 Glen Fernandes
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_DETAIL_NO_EXCEPTIONS_SUPPORT_HPP
+#define BOOST_DETAIL_NO_EXCEPTIONS_SUPPORT_HPP
+
+// The header file at this path is deprecated;
+// use boost/core/no_exceptions_support.hpp instead.
+
+#include <boost/core/no_exceptions_support.hpp>
+
+#endif

--- a/src/boost/detail/workaround.hpp
+++ b/src/boost/detail/workaround.hpp
@@ -1,0 +1,10 @@
+// Copyright David Abrahams 2002.
+// Distributed under the Boost Software License, Version 1.0. (See
+// accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+#ifndef WORKAROUND_DWA2002126_HPP
+#define WORKAROUND_DWA2002126_HPP
+
+#include <boost/config/workaround.hpp>
+
+#endif // WORKAROUND_DWA2002126_HPP

--- a/src/boost/exception/exception.hpp
+++ b/src/boost/exception/exception.hpp
@@ -1,0 +1,521 @@
+//Copyright (c) 2006-2009 Emil Dotchevski and Reverge Studios, Inc.
+
+//Distributed under the Boost Software License, Version 1.0. (See accompanying
+//file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef UUID_274DA366004E11DCB1DDFE2E56D89593
+#define UUID_274DA366004E11DCB1DDFE2E56D89593
+#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma GCC system_header
+#endif
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(push,1)
+#endif
+
+#ifdef BOOST_EXCEPTION_MINI_BOOST
+#include  <memory>
+namespace boost { namespace exception_detail { using std::shared_ptr; } }
+#else
+namespace boost { template <class T> class shared_ptr; };
+namespace boost { namespace exception_detail { using boost::shared_ptr; } }
+#endif
+
+namespace
+boost
+    {
+    namespace
+    exception_detail
+        {
+        template <class T>
+        class
+        refcount_ptr
+            {
+            public:
+
+            refcount_ptr():
+                px_(0)
+                {
+                }
+
+            ~refcount_ptr()
+                {
+                release();
+                }
+
+            refcount_ptr( refcount_ptr const & x ):
+                px_(x.px_)
+                {
+                add_ref();
+                }
+
+            refcount_ptr &
+            operator=( refcount_ptr const & x )
+                {
+                adopt(x.px_);
+                return *this;
+                }
+
+            void
+            adopt( T * px )
+                {
+                release();
+                px_=px;
+                add_ref();
+                }
+
+            T *
+            get() const
+                {
+                return px_;
+                }
+
+            private:
+
+            T * px_;
+
+            void
+            add_ref()
+                {
+                if( px_ )
+                    px_->add_ref();
+                }
+
+            void
+            release()
+                {
+                if( px_ && px_->release() )
+                    px_=0;
+                }
+            };
+        }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    template <class Tag,class T>
+    class error_info;
+
+    typedef error_info<struct throw_function_,char const *> throw_function;
+    typedef error_info<struct throw_file_,char const *> throw_file;
+    typedef error_info<struct throw_line_,int> throw_line;
+
+    template <>
+    class
+    error_info<throw_function_,char const *>
+        {
+        public:
+        typedef char const * value_type;
+        value_type v_;
+        explicit
+        error_info( value_type v ):
+            v_(v)
+            {
+            }
+        };
+
+    template <>
+    class
+    error_info<throw_file_,char const *>
+        {
+        public:
+        typedef char const * value_type;
+        value_type v_;
+        explicit
+        error_info( value_type v ):
+            v_(v)
+            {
+            }
+        };
+
+    template <>
+    class
+    error_info<throw_line_,int>
+        {
+        public:
+        typedef int value_type;
+        value_type v_;
+        explicit
+        error_info( value_type v ):
+            v_(v)
+            {
+            }
+        };
+
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
+    class exception;
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
+
+    namespace
+    exception_detail
+        {
+        class error_info_base;
+        struct type_info_;
+
+        struct
+        error_info_container
+            {
+            virtual char const * diagnostic_information( char const * ) const = 0;
+            virtual shared_ptr<error_info_base> get( type_info_ const & ) const = 0;
+            virtual void set( shared_ptr<error_info_base> const &, type_info_ const & ) = 0;
+            virtual void add_ref() const = 0;
+            virtual bool release() const = 0;
+            virtual refcount_ptr<exception_detail::error_info_container> clone() const = 0;
+
+            protected:
+
+            ~error_info_container() throw()
+                {
+                }
+            };
+
+        template <class>
+        struct get_info;
+
+        template <>
+        struct get_info<throw_function>;
+
+        template <>
+        struct get_info<throw_file>;
+
+        template <>
+        struct get_info<throw_line>;
+
+        template <class>
+        struct set_info_rv;
+
+        template <>
+        struct set_info_rv<throw_function>;
+
+        template <>
+        struct set_info_rv<throw_file>;
+
+        template <>
+        struct set_info_rv<throw_line>;
+
+        char const * get_diagnostic_information( exception const &, char const * );
+
+        void copy_boost_exception( exception *, exception const * );
+
+        template <class E,class Tag,class T>
+        E const & set_info( E const &, error_info<Tag,T> const & );
+
+        template <class E>
+        E const & set_info( E const &, throw_function const & );
+
+        template <class E>
+        E const & set_info( E const &, throw_file const & );
+
+        template <class E>
+        E const & set_info( E const &, throw_line const & );
+        }
+
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
+    class
+    exception
+        {
+        //<N3757>
+        public:
+        template <class Tag> void set( typename Tag::type const & );
+        template <class Tag> typename Tag::type const * get() const;
+        //</N3757>
+
+        protected:
+
+        exception():
+            throw_function_(0),
+            throw_file_(0),
+            throw_line_(-1)
+            {
+            }
+
+#ifdef __HP_aCC
+        //On HP aCC, this protected copy constructor prevents throwing boost::exception.
+        //On all other platforms, the same effect is achieved by the pure virtual destructor.
+        exception( exception const & x ) throw():
+            data_(x.data_),
+            throw_function_(x.throw_function_),
+            throw_file_(x.throw_file_),
+            throw_line_(x.throw_line_)
+            {
+            }
+#endif
+
+        virtual ~exception() throw()
+#ifndef __HP_aCC
+            = 0 //Workaround for HP aCC, =0 incorrectly leads to link errors.
+#endif
+            ;
+
+#if (defined(__MWERKS__) && __MWERKS__<=0x3207) || (defined(_MSC_VER) && _MSC_VER<=1310)
+        public:
+#else
+        private:
+
+        template <class E>
+        friend E const & exception_detail::set_info( E const &, throw_function const & );
+
+        template <class E>
+        friend E const & exception_detail::set_info( E const &, throw_file const & );
+
+        template <class E>
+        friend E const & exception_detail::set_info( E const &, throw_line const & );
+
+        template <class E,class Tag,class T>
+        friend E const & exception_detail::set_info( E const &, error_info<Tag,T> const & );
+
+        friend char const * exception_detail::get_diagnostic_information( exception const &, char const * );
+
+        template <class>
+        friend struct exception_detail::get_info;
+        friend struct exception_detail::get_info<throw_function>;
+        friend struct exception_detail::get_info<throw_file>;
+        friend struct exception_detail::get_info<throw_line>;
+        template <class>
+        friend struct exception_detail::set_info_rv;
+        friend struct exception_detail::set_info_rv<throw_function>;
+        friend struct exception_detail::set_info_rv<throw_file>;
+        friend struct exception_detail::set_info_rv<throw_line>;
+        friend void exception_detail::copy_boost_exception( exception *, exception const * );
+#endif
+        mutable exception_detail::refcount_ptr<exception_detail::error_info_container> data_;
+        mutable char const * throw_function_;
+        mutable char const * throw_file_;
+        mutable int throw_line_;
+        };
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
+
+    inline
+    exception::
+    ~exception() throw()
+        {
+        }
+
+    namespace
+    exception_detail
+        {
+        template <class E>
+        E const &
+        set_info( E const & x, throw_function const & y )
+            {
+            x.throw_function_=y.v_;
+            return x;
+            }
+
+        template <class E>
+        E const &
+        set_info( E const & x, throw_file const & y )
+            {
+            x.throw_file_=y.v_;
+            return x;
+            }
+
+        template <class E>
+        E const &
+        set_info( E const & x, throw_line const & y )
+            {
+            x.throw_line_=y.v_;
+            return x;
+            }
+        }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    namespace
+    exception_detail
+        {
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
+        template <class T>
+        struct
+        error_info_injector:
+            public T,
+            public exception
+            {
+            explicit
+            error_info_injector( T const & x ):
+                T(x)
+                {
+                }
+
+            ~error_info_injector() throw()
+                {
+                }
+            };
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
+
+        struct large_size { char c[256]; };
+        large_size dispatch_boost_exception( exception const * );
+
+        struct small_size { };
+        small_size dispatch_boost_exception( void const * );
+
+        template <class,int>
+        struct enable_error_info_helper;
+
+        template <class T>
+        struct
+        enable_error_info_helper<T,sizeof(large_size)>
+            {
+            typedef T type;
+            };
+
+        template <class T>
+        struct
+        enable_error_info_helper<T,sizeof(small_size)>
+            {
+            typedef error_info_injector<T> type;
+            };
+
+        template <class T>
+        struct
+        enable_error_info_return_type
+            {
+            typedef typename enable_error_info_helper<T,sizeof(exception_detail::dispatch_boost_exception(static_cast<T *>(0)))>::type type;
+            };
+        }
+
+    template <class T>
+    inline
+    typename
+    exception_detail::enable_error_info_return_type<T>::type
+    enable_error_info( T const & x )
+        {
+        typedef typename exception_detail::enable_error_info_return_type<T>::type rt;
+        return rt(x);
+        }
+
+    ////////////////////////////////////////////////////////////////////////
+
+    namespace
+    exception_detail
+        {
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
+        class
+        clone_base
+            {
+            public:
+
+            virtual clone_base const * clone() const = 0;
+            virtual void rethrow() const = 0;
+
+            virtual
+            ~clone_base() throw()
+                {
+                }
+            };
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
+
+        inline
+        void
+        copy_boost_exception( exception * a, exception const * b )
+            {
+            refcount_ptr<error_info_container> data;
+            if( error_info_container * d=b->data_.get() )
+                data = d->clone();
+            a->throw_file_ = b->throw_file_;
+            a->throw_line_ = b->throw_line_;
+            a->throw_function_ = b->throw_function_;
+            a->data_ = data;
+            }
+
+        inline
+        void
+        copy_boost_exception( void *, void const * )
+            {
+            }
+
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility push (default)
+# endif
+#endif
+        template <class T>
+        class
+        clone_impl:
+            public T,
+            public virtual clone_base
+            {
+            struct clone_tag { };
+            clone_impl( clone_impl const & x, clone_tag ):
+                T(x)
+                {
+                copy_boost_exception(this,&x);
+                }
+
+            public:
+
+            explicit
+            clone_impl( T const & x ):
+                T(x)
+                {
+                copy_boost_exception(this,&x);
+                }
+
+            ~clone_impl() throw()
+                {
+                }
+
+            private:
+
+            clone_base const *
+            clone() const
+                {
+                return new clone_impl(*this,clone_tag());
+                }
+
+            void
+            rethrow() const
+                {
+                throw*this;
+                }
+            };
+        }
+#if defined(__GNUC__)
+# if (__GNUC__ == 4 && __GNUC_MINOR__ >= 1) || (__GNUC__ > 4)
+#  pragma GCC visibility pop
+# endif
+#endif
+
+    template <class T>
+    inline
+    exception_detail::clone_impl<T>
+    enable_current_exception( T const & x )
+        {
+        return exception_detail::clone_impl<T>(x);
+        }
+    }
+
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(pop)
+#endif
+#endif

--- a/src/boost/integer/integer_log2.hpp
+++ b/src/boost/integer/integer_log2.hpp
@@ -1,0 +1,112 @@
+// -----------------------------------------------------------
+// integer_log2.hpp
+//
+//   Gives the integer part of the logarithm, in base 2, of a
+// given number. Behavior is undefined if the argument is <= 0.
+//
+//         Copyright (c) 2003-2004, 2008 Gennaro Prota
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// -----------------------------------------------------------
+
+#ifndef BOOST_INTEGER_INTEGER_LOG2_HPP
+#define BOOST_INTEGER_INTEGER_LOG2_HPP
+
+#include <assert.h>
+#ifdef __BORLANDC__
+#include <climits>
+#endif
+#include <boost/limits.hpp>
+#include <boost/config.hpp>
+
+
+namespace boost {
+ namespace detail {
+
+  template <typename T>
+  int integer_log2_impl(T x, int n) {
+
+      int result = 0;
+
+      while (x != 1) {
+
+          const T t = static_cast<T>(x >> n);
+          if (t) {
+              result += n;
+              x = t;
+          }
+          n /= 2;
+
+      }
+
+      return result;
+  }
+
+
+
+  // helper to find the maximum power of two
+  // less than p (more involved than necessary,
+  // to avoid PTS)
+  //
+  template <int p, int n>
+  struct max_pow2_less {
+
+      enum { c = 2*n < p };
+
+      BOOST_STATIC_CONSTANT(int, value =
+          c ? (max_pow2_less< c*p, 2*c*n>::value) : n);
+
+  };
+
+  template <>
+  struct max_pow2_less<0, 0> {
+
+      BOOST_STATIC_CONSTANT(int, value = 0);
+  };
+
+  // this template is here just for Borland :(
+  // we could simply rely on numeric_limits but sometimes
+  // Borland tries to use numeric_limits<const T>, because
+  // of its usual const-related problems in argument deduction
+  // - gps
+  template <typename T>
+  struct width {
+
+#ifdef __BORLANDC__
+      BOOST_STATIC_CONSTANT(int, value = sizeof(T) * CHAR_BIT);
+#else
+      BOOST_STATIC_CONSTANT(int, value = (std::numeric_limits<T>::digits));
+#endif
+
+  };
+
+ } // detail
+
+
+ // ---------
+ // integer_log2
+ // ---------------
+ //
+ template <typename T>
+ int integer_log2(T x) {
+
+     assert(x > 0);
+
+     const int n = detail::max_pow2_less<
+                     detail::width<T> :: value, 4
+                   > :: value;
+
+     return detail::integer_log2_impl(x, n);
+
+ }
+
+
+
+}
+
+
+
+#endif // include guard

--- a/src/boost/limits.hpp
+++ b/src/boost/limits.hpp
@@ -1,0 +1,146 @@
+
+//  (C) Copyright John maddock 1999. 
+//  (C) David Abrahams 2002.  Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// use this header as a workaround for missing <limits>
+
+//  See http://www.boost.org/libs/compatibility/index.html for documentation.
+
+#ifndef BOOST_LIMITS
+#define BOOST_LIMITS
+
+#include <boost/config.hpp>
+
+#ifdef BOOST_NO_LIMITS
+#  error "There is no std::numeric_limits suppport available."
+#else
+# include <limits>
+#endif
+
+#if (defined(BOOST_HAS_LONG_LONG) && defined(BOOST_NO_LONG_LONG_NUMERIC_LIMITS)) \
+      || (defined(BOOST_HAS_MS_INT64) && defined(BOOST_NO_MS_INT64_NUMERIC_LIMITS))
+// Add missing specializations for numeric_limits:
+#ifdef BOOST_HAS_MS_INT64
+#  define BOOST_LLT __int64
+#  define BOOST_ULLT unsigned __int64
+#else
+#  define BOOST_LLT  ::boost::long_long_type
+#  define BOOST_ULLT  ::boost::ulong_long_type
+#endif
+
+#include <climits>  // for CHAR_BIT
+
+namespace std
+{
+  template<>
+  class numeric_limits<BOOST_LLT> 
+  {
+   public:
+
+      BOOST_STATIC_CONSTANT(bool, is_specialized = true);
+#ifdef BOOST_HAS_MS_INT64
+      static BOOST_LLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 0x8000000000000000i64; }
+      static BOOST_LLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 0x7FFFFFFFFFFFFFFFi64; }
+#elif defined(LLONG_MAX)
+      static BOOST_LLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return LLONG_MIN; }
+      static BOOST_LLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return LLONG_MAX; }
+#elif defined(LONGLONG_MAX)
+      static BOOST_LLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return LONGLONG_MIN; }
+      static BOOST_LLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return LONGLONG_MAX; }
+#else
+      static BOOST_LLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 1LL << (sizeof(BOOST_LLT) * CHAR_BIT - 1); }
+      static BOOST_LLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ~(min)(); }
+#endif
+      BOOST_STATIC_CONSTANT(int, digits = sizeof(BOOST_LLT) * CHAR_BIT -1);
+      BOOST_STATIC_CONSTANT(int, digits10 = (CHAR_BIT * sizeof (BOOST_LLT) - 1) * 301L / 1000);
+      BOOST_STATIC_CONSTANT(bool, is_signed = true);
+      BOOST_STATIC_CONSTANT(bool, is_integer = true);
+      BOOST_STATIC_CONSTANT(bool, is_exact = true);
+      BOOST_STATIC_CONSTANT(int, radix = 2);
+      static BOOST_LLT epsilon() throw() { return 0; };
+      static BOOST_LLT round_error() throw() { return 0; };
+
+      BOOST_STATIC_CONSTANT(int, min_exponent = 0);
+      BOOST_STATIC_CONSTANT(int, min_exponent10 = 0);
+      BOOST_STATIC_CONSTANT(int, max_exponent = 0);
+      BOOST_STATIC_CONSTANT(int, max_exponent10 = 0);
+
+      BOOST_STATIC_CONSTANT(bool, has_infinity = false);
+      BOOST_STATIC_CONSTANT(bool, has_quiet_NaN = false);
+      BOOST_STATIC_CONSTANT(bool, has_signaling_NaN = false);
+      BOOST_STATIC_CONSTANT(bool, has_denorm = false);
+      BOOST_STATIC_CONSTANT(bool, has_denorm_loss = false);
+      static BOOST_LLT infinity() throw() { return 0; };
+      static BOOST_LLT quiet_NaN() throw() { return 0; };
+      static BOOST_LLT signaling_NaN() throw() { return 0; };
+      static BOOST_LLT denorm_min() throw() { return 0; };
+
+      BOOST_STATIC_CONSTANT(bool, is_iec559 = false);
+      BOOST_STATIC_CONSTANT(bool, is_bounded = true);
+      BOOST_STATIC_CONSTANT(bool, is_modulo = true);
+
+      BOOST_STATIC_CONSTANT(bool, traps = false);
+      BOOST_STATIC_CONSTANT(bool, tinyness_before = false);
+      BOOST_STATIC_CONSTANT(float_round_style, round_style = round_toward_zero);
+      
+  };
+
+  template<>
+  class numeric_limits<BOOST_ULLT> 
+  {
+   public:
+
+      BOOST_STATIC_CONSTANT(bool, is_specialized = true);
+#ifdef BOOST_HAS_MS_INT64
+      static BOOST_ULLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 0ui64; }
+      static BOOST_ULLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 0xFFFFFFFFFFFFFFFFui64; }
+#elif defined(ULLONG_MAX) && defined(ULLONG_MIN)
+      static BOOST_ULLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ULLONG_MIN; }
+      static BOOST_ULLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ULLONG_MAX; }
+#elif defined(ULONGLONG_MAX) && defined(ULONGLONG_MIN)
+      static BOOST_ULLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ULONGLONG_MIN; }
+      static BOOST_ULLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ULONGLONG_MAX; }
+#else
+      static BOOST_ULLT min BOOST_PREVENT_MACRO_SUBSTITUTION (){ return 0uLL; }
+      static BOOST_ULLT max BOOST_PREVENT_MACRO_SUBSTITUTION (){ return ~0uLL; }
+#endif
+      BOOST_STATIC_CONSTANT(int, digits = sizeof(BOOST_LLT) * CHAR_BIT);
+      BOOST_STATIC_CONSTANT(int, digits10 = (CHAR_BIT * sizeof (BOOST_LLT)) * 301L / 1000);
+      BOOST_STATIC_CONSTANT(bool, is_signed = false);
+      BOOST_STATIC_CONSTANT(bool, is_integer = true);
+      BOOST_STATIC_CONSTANT(bool, is_exact = true);
+      BOOST_STATIC_CONSTANT(int, radix = 2);
+      static BOOST_ULLT epsilon() throw() { return 0; };
+      static BOOST_ULLT round_error() throw() { return 0; };
+
+      BOOST_STATIC_CONSTANT(int, min_exponent = 0);
+      BOOST_STATIC_CONSTANT(int, min_exponent10 = 0);
+      BOOST_STATIC_CONSTANT(int, max_exponent = 0);
+      BOOST_STATIC_CONSTANT(int, max_exponent10 = 0);
+
+      BOOST_STATIC_CONSTANT(bool, has_infinity = false);
+      BOOST_STATIC_CONSTANT(bool, has_quiet_NaN = false);
+      BOOST_STATIC_CONSTANT(bool, has_signaling_NaN = false);
+      BOOST_STATIC_CONSTANT(bool, has_denorm = false);
+      BOOST_STATIC_CONSTANT(bool, has_denorm_loss = false);
+      static BOOST_ULLT infinity() throw() { return 0; };
+      static BOOST_ULLT quiet_NaN() throw() { return 0; };
+      static BOOST_ULLT signaling_NaN() throw() { return 0; };
+      static BOOST_ULLT denorm_min() throw() { return 0; };
+
+      BOOST_STATIC_CONSTANT(bool, is_iec559 = false);
+      BOOST_STATIC_CONSTANT(bool, is_bounded = true);
+      BOOST_STATIC_CONSTANT(bool, is_modulo = true);
+
+      BOOST_STATIC_CONSTANT(bool, traps = false);
+      BOOST_STATIC_CONSTANT(bool, tinyness_before = false);
+      BOOST_STATIC_CONSTANT(float_round_style, round_style = round_toward_zero);
+      
+  };
+}
+#endif 
+
+#endif
+

--- a/src/boost/move/algo/move.hpp
+++ b/src/boost/move/algo/move.hpp
@@ -1,0 +1,156 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2016.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_ALGO_MOVE_HPP
+#define BOOST_MOVE_ALGO_MOVE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+
+#include <boost/move/utility_core.hpp>
+#include <boost/move/detail/iterator_traits.hpp>
+#include <boost/move/detail/iterator_to_raw_pointer.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+
+namespace boost {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                               move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#if !defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+   //! <b>Effects</b>: Moves elements in the range [first,last) into the range [result,result + (last -
+   //!   first)) starting from first and proceeding to last. For each non-negative integer n < (last-first),
+   //!   performs *(result + n) = ::boost::move (*(first + n)).
+   //!
+   //! <b>Effects</b>: result + (last - first).
+   //!
+   //! <b>Requires</b>: result shall not be in the range [first,last).
+   //!
+   //! <b>Complexity</b>: Exactly last - first move assignments.
+   template <typename I, // I models InputIterator
+            typename O> // O models OutputIterator
+   O move(I f, I l, O result)
+   {
+      while (f != l) {
+         *result = ::boost::move(*f);
+         ++f; ++result;
+      }
+      return result;
+   }
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                               move_backward
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   //! <b>Effects</b>: Moves elements in the range [first,last) into the range
+   //!   [result - (last-first),result) starting from last - 1 and proceeding to
+   //!   first. For each positive integer n <= (last - first),
+   //!   performs *(result - n) = ::boost::move(*(last - n)).
+   //!
+   //! <b>Requires</b>: result shall not be in the range [first,last).
+   //!
+   //! <b>Returns</b>: result - (last - first).
+   //!
+   //! <b>Complexity</b>: Exactly last - first assignments.
+   template <typename I, // I models BidirectionalIterator
+   typename O> // O models BidirectionalIterator
+   O move_backward(I f, I l, O result)
+   {
+      while (f != l) {
+         --l; --result;
+         *result = ::boost::move(*l);
+      }
+      return result;
+   }
+
+#else
+
+   using ::std::move_backward;
+
+#endif   //!defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                               uninitialized_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      new (static_cast<void*>(&*result))
+//!         typename iterator_traits<ForwardIterator>::value_type(boost::move(*first));
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+template
+   <typename I, // I models InputIterator
+    typename F> // F models ForwardIterator
+F uninitialized_move(I f, I l, F r
+   /// @cond
+//   ,typename ::boost::move_detail::enable_if<has_move_emulation_enabled<typename boost::movelib::iterator_traits<I>::value_type> >::type* = 0
+   /// @endcond
+   )
+{
+   typedef typename boost::movelib::iterator_traits<I>::value_type input_value_type;
+
+   F back = r;
+   BOOST_TRY{
+      while (f != l) {
+         void * const addr = static_cast<void*>(::boost::move_detail::addressof(*r));
+         ::new(addr) input_value_type(::boost::move(*f));
+         ++f; ++r;
+      }
+   }
+   BOOST_CATCH(...){
+      for (; back != r; ++back){
+         boost::movelib::iterator_to_raw_pointer(back)->~input_value_type();
+      }
+      BOOST_RETHROW;
+   }
+   BOOST_CATCH_END
+   return r;
+}
+
+/// @cond
+/*
+template
+   <typename I,   // I models InputIterator
+    typename F>   // F models ForwardIterator
+F uninitialized_move(I f, I l, F r,
+   typename ::boost::move_detail::disable_if<has_move_emulation_enabled<typename boost::movelib::iterator_traits<I>::value_type> >::type* = 0)
+{
+   return std::uninitialized_copy(f, l, r);
+}
+*/
+
+/// @endcond
+
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_ALGO_MOVE_HPP

--- a/src/boost/move/algorithm.hpp
+++ b/src/boost/move/algorithm.hpp
@@ -1,0 +1,167 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_ALGORITHM_HPP
+#define BOOST_MOVE_ALGORITHM_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+
+#include <boost/move/utility_core.hpp>
+#include <boost/move/iterator.hpp>
+#include <boost/move/algo/move.hpp>
+#include <boost/detail/no_exceptions_support.hpp>
+
+#include <algorithm> //copy, copy_backward
+#include <memory>    //uninitialized_copy
+
+namespace boost {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            uninitialized_copy_or_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_move_move_iterator(I f, I l, F r
+//                             ,typename ::boost::move_detail::enable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0
+)
+{
+   return ::boost::uninitialized_move(f, l, r);
+}
+/*
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+F uninitialized_move_move_iterator(I f, I l, F r,
+                                   typename ::boost::move_detail::disable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0)
+{
+   return std::uninitialized_copy(f.base(), l.base(), r);
+}
+*/
+}  //namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_copy_or_move(I f, I l, F r,
+                             typename ::boost::move_detail::enable_if< move_detail::is_move_iterator<I> >::type* = 0)
+{
+   return ::boost::move_detail::uninitialized_move_move_iterator(f, l, r);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            copy_or_move
+//
+//////////////////////////////////////////////////////////////////////////////
+
+namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F move_move_iterator(I f, I l, F r
+//                             ,typename ::boost::move_detail::enable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0
+)
+{
+   return ::boost::move(f, l, r);
+}
+/*
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+F move_move_iterator(I f, I l, F r,
+                                   typename ::boost::move_detail::disable_if< has_move_emulation_enabled<typename I::value_type> >::type* = 0)
+{
+   return std::copy(f.base(), l.base(), r);
+}
+*/
+
+}  //namespace move_detail {
+
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F copy_or_move(I f, I l, F r,
+                             typename ::boost::move_detail::enable_if< move_detail::is_move_iterator<I> >::type* = 0)
+{
+   return ::boost::move_detail::move_move_iterator(f, l, r);
+}
+
+/// @endcond
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      new (static_cast<void*>(&*result))
+//!         typename iterator_traits<ForwardIterator>::value_type(*first);
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+//!
+//! <b>Note</b>: This function is provided because
+//!   <i>std::uninitialized_copy</i> from some STL implementations
+//!    is not compatible with <i>move_iterator</i>
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F uninitialized_copy_or_move(I f, I l, F r
+   /// @cond
+   ,typename ::boost::move_detail::disable_if< move_detail::is_move_iterator<I> >::type* = 0
+   /// @endcond
+   )
+{
+   return std::uninitialized_copy(f, l, r);
+}
+
+//! <b>Effects</b>:
+//!   \code
+//!   for (; first != last; ++result, ++first)
+//!      *result = *first;
+//!   \endcode
+//!
+//! <b>Returns</b>: result
+//!
+//! <b>Note</b>: This function is provided because
+//!   <i>std::uninitialized_copy</i> from some STL implementations
+//!    is not compatible with <i>move_iterator</i>
+template
+<typename I,   // I models InputIterator
+typename F>   // F models ForwardIterator
+inline F copy_or_move(I f, I l, F r
+   /// @cond
+   ,typename ::boost::move_detail::disable_if< move_detail::is_move_iterator<I> >::type* = 0
+   /// @endcond
+   )
+{
+   return std::copy(f, l, r);
+}
+
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_ALGORITHM_HPP

--- a/src/boost/move/core.hpp
+++ b/src/boost/move/core.hpp
@@ -1,0 +1,494 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+//! This header implements macros to define movable classes and
+//! move-aware functions
+
+#ifndef BOOST_MOVE_CORE_HPP
+#define BOOST_MOVE_CORE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>
+
+// @cond
+
+//boost_move_no_copy_constructor_or_assign typedef
+//used to detect noncopyable types for other Boost libraries.
+#if defined(BOOST_NO_CXX11_DELETED_FUNCTIONS) || defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+   #define BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE) \
+      private:\
+      TYPE(TYPE &);\
+      TYPE& operator=(TYPE &);\
+      public:\
+      typedef int boost_move_no_copy_constructor_or_assign; \
+      private:\
+   //
+#else
+   #define BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE) \
+      public:\
+      TYPE(TYPE const &) = delete;\
+      TYPE& operator=(TYPE const &) = delete;\
+      public:\
+      typedef int boost_move_no_copy_constructor_or_assign; \
+      private:\
+   //
+#endif   //BOOST_NO_CXX11_DELETED_FUNCTIONS
+
+// @endcond
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   #include <boost/move/detail/type_traits.hpp>
+
+   #if defined(BOOST_MOVE_ADDRESS_SANITIZER_ON)
+      #define BOOST_MOVE_TO_RV_CAST(RV_TYPE, ARG) reinterpret_cast<RV_TYPE>(ARG)
+   #else
+      #define BOOST_MOVE_TO_RV_CAST(RV_TYPE, ARG) static_cast<RV_TYPE>(ARG)
+   #endif
+
+   //Move emulation rv breaks standard aliasing rules so add workarounds for some compilers
+   #define BOOST_MOVE_ATTRIBUTE_MAY_ALIAS BOOST_MAY_ALIAS
+
+   namespace boost {
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                            struct rv
+   //
+   //////////////////////////////////////////////////////////////////////////////
+   template <class T>
+   class rv
+      : public ::boost::move_detail::if_c
+         < ::boost::move_detail::is_class<T>::value
+         , T
+         , ::boost::move_detail::nat
+         >::type
+   {
+      rv();
+      ~rv() throw();
+      rv(rv const&);
+      void operator=(rv const&);
+   } BOOST_MOVE_ATTRIBUTE_MAY_ALIAS;
+
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                            is_rv
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   namespace move_detail {
+
+   template <class T>
+   struct is_rv
+        //Derive from integral constant because some Boost code assummes it has
+        //a "type" internal typedef
+      : integral_constant<bool, ::boost::move_detail::is_rv_impl<T>::value >
+   {};
+
+   template <class T>
+   struct is_not_rv
+   {
+      static const bool value = !is_rv<T>::value;
+   };
+
+   }  //namespace move_detail {
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                               has_move_emulation_enabled
+   //
+   //////////////////////////////////////////////////////////////////////////////
+   template<class T>
+   struct has_move_emulation_enabled
+      : ::boost::move_detail::has_move_emulation_enabled_impl<T>
+   {};
+
+   template<class T>
+   struct has_move_emulation_disabled
+   {
+      static const bool value = !::boost::move_detail::has_move_emulation_enabled_impl<T>::value;
+   };
+
+   }  //namespace boost {
+
+   #define BOOST_RV_REF(TYPE)\
+      ::boost::rv< TYPE >& \
+   //
+
+   #define BOOST_RV_REF_2_TEMPL_ARGS(TYPE, ARG1, ARG2)\
+      ::boost::rv< TYPE<ARG1, ARG2> >& \
+   //
+
+   #define BOOST_RV_REF_3_TEMPL_ARGS(TYPE, ARG1, ARG2, ARG3)\
+      ::boost::rv< TYPE<ARG1, ARG2, ARG3> >& \
+   //
+
+   #define BOOST_RV_REF_BEG\
+      ::boost::rv<   \
+   //
+
+   #define BOOST_RV_REF_END\
+      >& \
+   //
+
+   #define BOOST_RV_REF_BEG_IF_CXX11 \
+      \
+   //
+
+   #define BOOST_RV_REF_END_IF_CXX11 \
+      \
+   //
+
+   #define BOOST_FWD_REF(TYPE)\
+      const TYPE & \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF(TYPE)\
+      const ::boost::rv< TYPE >& \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_BEG \
+      const ::boost::rv<  \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_END \
+      >& \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_2_TEMPL_ARGS(TYPE, ARG1, ARG2)\
+      const ::boost::rv< TYPE<ARG1, ARG2> >& \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_3_TEMPL_ARGS(TYPE, ARG1, ARG2, ARG3)\
+      const ::boost::rv< TYPE<ARG1, ARG2, ARG3> >& \
+   //
+
+   #define BOOST_CATCH_CONST_RLVALUE(TYPE)\
+      const ::boost::rv< TYPE >& \
+   //
+
+   namespace boost {
+   namespace move_detail {
+
+   template <class Ret, class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      <  ::boost::move_detail::is_lvalue_reference<Ret>::value ||
+        !::boost::has_move_emulation_enabled<T>::value
+      , T&>::type
+         move_return(T& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class Ret, class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < !::boost::move_detail::is_lvalue_reference<Ret>::value &&
+         ::boost::has_move_emulation_enabled<T>::value
+      , ::boost::rv<T>&>::type
+         move_return(T& x) BOOST_NOEXCEPT
+   {
+      return *BOOST_MOVE_TO_RV_CAST(::boost::rv<T>*, ::boost::move_detail::addressof(x));
+   }
+
+   template <class Ret, class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < !::boost::move_detail::is_lvalue_reference<Ret>::value &&
+         ::boost::has_move_emulation_enabled<T>::value
+      , ::boost::rv<T>&>::type
+         move_return(::boost::rv<T>& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   }  //namespace move_detail {
+   }  //namespace boost {
+
+   #define BOOST_MOVE_RET(RET_TYPE, REF)\
+      boost::move_detail::move_return< RET_TYPE >(REF)
+   //
+
+   #define BOOST_MOVE_BASE(BASE_TYPE, ARG) \
+      ::boost::move((BASE_TYPE&)(ARG))
+   //
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                         BOOST_MOVABLE_BUT_NOT_COPYABLE
+   //
+   //////////////////////////////////////////////////////////////////////////////
+   #define BOOST_MOVABLE_BUT_NOT_COPYABLE(TYPE)\
+      BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE)\
+      public:\
+      BOOST_MOVE_FORCEINLINE operator ::boost::rv<TYPE>&() \
+      {  return *BOOST_MOVE_TO_RV_CAST(::boost::rv<TYPE>*, this);  }\
+      BOOST_MOVE_FORCEINLINE operator const ::boost::rv<TYPE>&() const \
+      {  return *BOOST_MOVE_TO_RV_CAST(const ::boost::rv<TYPE>*, this);  }\
+      private:\
+   //
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                         BOOST_COPYABLE_AND_MOVABLE
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   #define BOOST_COPYABLE_AND_MOVABLE(TYPE)\
+      public:\
+      BOOST_MOVE_FORCEINLINE TYPE& operator=(TYPE &t)\
+      {  this->operator=(const_cast<const TYPE&>(t)); return *this;}\
+      public:\
+      BOOST_MOVE_FORCEINLINE operator ::boost::rv<TYPE>&() \
+      {  return *BOOST_MOVE_TO_RV_CAST(::boost::rv<TYPE>*, this);  }\
+      BOOST_MOVE_FORCEINLINE operator const ::boost::rv<TYPE>&() const \
+      {  return *BOOST_MOVE_TO_RV_CAST(const ::boost::rv<TYPE>*, this);  }\
+      private:\
+   //
+
+   #define BOOST_COPYABLE_AND_MOVABLE_ALT(TYPE)\
+      public:\
+      BOOST_MOVE_FORCEINLINE operator ::boost::rv<TYPE>&() \
+      {  return *BOOST_MOVE_TO_RV_CAST(::boost::rv<TYPE>*, this);  }\
+      BOOST_MOVE_FORCEINLINE operator const ::boost::rv<TYPE>&() const \
+      {  return *BOOST_MOVE_TO_RV_CAST(const ::boost::rv<TYPE>*, this);  }\
+      private:\
+   //
+
+   namespace boost{
+   namespace move_detail{
+
+   template< class T>
+   struct forward_type
+   { typedef const T &type; };
+
+   template< class T>
+   struct forward_type< boost::rv<T> >
+   { typedef T type; };
+
+   }}
+
+#else    //BOOST_NO_CXX11_RVALUE_REFERENCES
+
+   //! This macro marks a type as movable but not copyable, disabling copy construction
+   //! and assignment. The user will need to write a move constructor/assignment as explained
+   //! in the documentation to fully write a movable but not copyable class.
+   #define BOOST_MOVABLE_BUT_NOT_COPYABLE(TYPE)\
+      BOOST_MOVE_IMPL_NO_COPY_CTOR_OR_ASSIGN(TYPE)\
+      public:\
+      typedef int boost_move_emulation_t;\
+      private:\
+   //
+
+   //! This macro marks a type as copyable and movable.
+   //! The user will need to write a move constructor/assignment and a copy assignment
+   //! as explained in the documentation to fully write a copyable and movable class.
+   #define BOOST_COPYABLE_AND_MOVABLE(TYPE)\
+   //
+
+   #if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   #define BOOST_COPYABLE_AND_MOVABLE_ALT(TYPE)\
+   //
+   #endif   //#if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   namespace boost {
+
+   //!This trait yields to a compile-time true boolean if T was marked as
+   //!BOOST_MOVABLE_BUT_NOT_COPYABLE or BOOST_COPYABLE_AND_MOVABLE and
+   //!rvalue references are not available on the platform. False otherwise.
+   template<class T>
+   struct has_move_emulation_enabled
+   {
+      static const bool value = false;
+   };
+
+   template<class T>
+   struct has_move_emulation_disabled
+   {
+      static const bool value = true;
+   };
+
+   }  //namespace boost{
+
+   //!This macro is used to achieve portable syntax in move
+   //!constructors and assignments for classes marked as
+   //!BOOST_COPYABLE_AND_MOVABLE or BOOST_MOVABLE_BUT_NOT_COPYABLE
+   #define BOOST_RV_REF(TYPE)\
+      TYPE && \
+   //
+
+   //!This macro is used to achieve portable syntax in move
+   //!constructors and assignments for template classes marked as
+   //!BOOST_COPYABLE_AND_MOVABLE or BOOST_MOVABLE_BUT_NOT_COPYABLE.
+   //!As macros have problems with comma-separated template arguments,
+   //!the template argument must be preceded with BOOST_RV_REF_BEG
+   //!and ended with BOOST_RV_REF_END
+   #define BOOST_RV_REF_BEG\
+         \
+   //
+
+   //!This macro is used to achieve portable syntax in move
+   //!constructors and assignments for template classes marked as
+   //!BOOST_COPYABLE_AND_MOVABLE or BOOST_MOVABLE_BUT_NOT_COPYABLE.
+   //!As macros have problems with comma-separated template arguments,
+   //!the template argument must be preceded with BOOST_RV_REF_BEG
+   //!and ended with BOOST_RV_REF_END
+   #define BOOST_RV_REF_END\
+      && \
+   //
+
+   //!This macro expands to BOOST_RV_REF_BEG if BOOST_NO_CXX11_RVALUE_REFERENCES
+   //!is not defined, empty otherwise
+   #define BOOST_RV_REF_BEG_IF_CXX11 \
+      BOOST_RV_REF_BEG \
+   //
+
+   //!This macro expands to BOOST_RV_REF_END if BOOST_NO_CXX11_RVALUE_REFERENCES
+   //!is not defined, empty otherwise
+   #define BOOST_RV_REF_END_IF_CXX11 \
+      BOOST_RV_REF_END \
+   //
+
+   //!This macro is used to achieve portable syntax in copy
+   //!assignment for classes marked as BOOST_COPYABLE_AND_MOVABLE.
+   #define BOOST_COPY_ASSIGN_REF(TYPE)\
+      const TYPE & \
+   //
+
+   //! This macro is used to implement portable perfect forwarding
+   //! as explained in the documentation.
+   #define BOOST_FWD_REF(TYPE)\
+      TYPE && \
+   //
+
+   #if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   #define BOOST_RV_REF_2_TEMPL_ARGS(TYPE, ARG1, ARG2)\
+      TYPE<ARG1, ARG2> && \
+   //
+
+   #define BOOST_RV_REF_3_TEMPL_ARGS(TYPE, ARG1, ARG2, ARG3)\
+      TYPE<ARG1, ARG2, ARG3> && \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_BEG \
+      const \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_END \
+      & \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_2_TEMPL_ARGS(TYPE, ARG1, ARG2)\
+      const TYPE<ARG1, ARG2> & \
+   //
+
+   #define BOOST_COPY_ASSIGN_REF_3_TEMPL_ARGS(TYPE, ARG1, ARG2, ARG3)\
+      const TYPE<ARG1, ARG2, ARG3>& \
+   //
+
+   #define BOOST_CATCH_CONST_RLVALUE(TYPE)\
+      const TYPE & \
+   //
+
+   #endif   //#if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   #if !defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+      //!This macro is used to achieve portable move return semantics.
+      //!The C++11 Standard allows implicit move returns when the object to be returned
+      //!is designated by a lvalue and:
+      //!   - The criteria for elision of a copy operation are met OR
+      //!   - The criteria would be met save for the fact that the source object is a function parameter
+      //!
+      //!For C++11 conforming compilers this macros only yields to REF:
+      //! <code>return BOOST_MOVE_RET(RET_TYPE, REF);</code> -> <code>return REF;</code>
+      //!
+      //!For compilers without rvalue references
+      //!this macro does an explicit move if the move emulation is activated
+      //!and the return type (RET_TYPE) is not a reference.
+      //!
+      //!For non-conforming compilers with rvalue references like Visual 2010 & 2012,
+      //!an explicit move is performed if RET_TYPE is not a reference.
+      //!
+      //! <b>Caution</b>: When using this macro in non-conforming or C++03
+      //!compilers, a move will be performed even if the C++11 standard does not allow it
+      //!(e.g. returning a static variable). The user is responsible for using this macro
+      //!only to return local objects that met C++11 criteria.
+      #define BOOST_MOVE_RET(RET_TYPE, REF)\
+         REF
+      //
+
+   #else //!defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+      #include <boost/move/detail/meta_utils.hpp>
+
+      namespace boost {
+      namespace move_detail {
+
+      template <class Ret, class T>
+      BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+         <  ::boost::move_detail::is_lvalue_reference<Ret>::value
+         , T&>::type
+            move_return(T& x) BOOST_NOEXCEPT
+      {
+         return x;
+      }
+
+      template <class Ret, class T>
+      BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+         < !::boost::move_detail::is_lvalue_reference<Ret>::value
+         , Ret && >::type
+            move_return(T&& t) BOOST_NOEXCEPT
+      {
+         return static_cast< Ret&& >(t);
+      }
+
+      }  //namespace move_detail {
+      }  //namespace boost {
+
+      #define BOOST_MOVE_RET(RET_TYPE, REF)\
+         boost::move_detail::move_return< RET_TYPE >(REF)
+      //
+
+   #endif   //!defined(BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   //!This macro is used to achieve portable optimal move constructors.
+   //!
+   //!When implementing the move constructor, in C++03 compilers the moved-from argument must be
+   //!cast to the base type before calling `::boost::move()` due to rvalue reference limitations.
+   //!
+   //!In C++11 compilers the cast from a rvalue reference of a derived type to a rvalue reference of
+   //!a base type is implicit.
+   #define BOOST_MOVE_BASE(BASE_TYPE, ARG) \
+      ::boost::move((BASE_TYPE&)(ARG))
+   //
+
+   namespace boost {
+   namespace move_detail {
+
+   template< class T> struct forward_type { typedef T type; };
+
+   }}
+
+#endif   //BOOST_NO_CXX11_RVALUE_REFERENCES
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_CORE_HPP

--- a/src/boost/move/detail/config_begin.hpp
+++ b/src/boost/move/detail/config_begin.hpp
@@ -1,0 +1,21 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+#ifndef BOOST_CONFIG_HPP
+#include <boost/config.hpp>
+#endif
+
+#ifdef BOOST_MSVC
+#  pragma warning (push)
+#  pragma warning (disable : 4324) // structure was padded due to __declspec(align())
+#  pragma warning (disable : 4675) // "function":  resolved overload was found by argument-dependent lookup
+#  pragma warning (disable : 4996) // "function": was declared deprecated (_CRT_SECURE_NO_DEPRECATE/_SCL_SECURE_NO_WARNINGS)
+#  pragma warning (disable : 4714) // "function": marked as __forceinline not inlined
+#  pragma warning (disable : 4127) // conditional expression is constant
+#endif

--- a/src/boost/move/detail/config_end.hpp
+++ b/src/boost/move/detail/config_end.hpp
@@ -1,0 +1,12 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+#if defined BOOST_MSVC
+#  pragma warning (pop)
+#endif

--- a/src/boost/move/detail/iterator_to_raw_pointer.hpp
+++ b/src/boost/move/detail/iterator_to_raw_pointer.hpp
@@ -1,0 +1,59 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2014-2015. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/container for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+#ifndef BOOST_MOVE_DETAIL_ITERATOR_TO_RAW_POINTER_HPP
+#define BOOST_MOVE_DETAIL_ITERATOR_TO_RAW_POINTER_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/iterator_traits.hpp>
+#include <boost/move/detail/to_raw_pointer.hpp>
+#include <boost/move/detail/pointer_element.hpp>
+
+namespace boost {
+namespace movelib {
+namespace detail {
+
+template <class T>
+inline T* iterator_to_pointer(T* i)
+{  return i; }
+
+template <class Iterator>
+inline typename boost::movelib::iterator_traits<Iterator>::pointer
+   iterator_to_pointer(const Iterator &i)
+{  return i.operator->();  }
+
+template <class Iterator>
+struct iterator_to_element_ptr
+{
+   typedef typename boost::movelib::iterator_traits<Iterator>::pointer  pointer;
+   typedef typename boost::movelib::pointer_element<pointer>::type      element_type;
+   typedef element_type* type;
+};
+
+}  //namespace detail {
+
+template <class Iterator>
+inline typename boost::movelib::detail::iterator_to_element_ptr<Iterator>::type
+   iterator_to_raw_pointer(const Iterator &i)
+{
+   return ::boost::movelib::to_raw_pointer
+      (  ::boost::movelib::detail::iterator_to_pointer(i)   );
+}
+
+}  //namespace movelib {
+}  //namespace boost {
+
+#endif   //#ifndef BOOST_MOVE_DETAIL_ITERATOR_TO_RAW_POINTER_HPP

--- a/src/boost/move/detail/iterator_traits.hpp
+++ b/src/boost/move/detail/iterator_traits.hpp
@@ -1,0 +1,77 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2014-2014.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP
+#define BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <cstddef>
+#include <boost/move/detail/type_traits.hpp>
+
+#include <boost/move/detail/std_ns_begin.hpp>
+BOOST_MOVE_STD_NS_BEG
+
+struct input_iterator_tag;
+struct forward_iterator_tag;
+struct bidirectional_iterator_tag;
+struct random_access_iterator_tag;
+struct output_iterator_tag;
+
+BOOST_MOVE_STD_NS_END
+#include <boost/move/detail/std_ns_end.hpp>
+
+namespace boost{  namespace movelib{
+
+template<class Iterator>
+struct iterator_traits
+{
+   typedef typename Iterator::difference_type   difference_type;
+   typedef typename Iterator::value_type        value_type;
+   typedef typename Iterator::pointer           pointer;
+   typedef typename Iterator::reference         reference;
+   typedef typename Iterator::iterator_category iterator_category;
+   typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
+};
+
+template<class T>
+struct iterator_traits<T*>
+{
+   typedef std::ptrdiff_t                    difference_type;
+   typedef T                                 value_type;
+   typedef T*                                pointer;
+   typedef T&                                reference;
+   typedef std::random_access_iterator_tag   iterator_category;
+   typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
+};
+
+template<class T>
+struct iterator_traits<const T*>
+{
+   typedef std::ptrdiff_t                    difference_type;
+   typedef T                                 value_type;
+   typedef const T*                          pointer;
+   typedef const T&                          reference;
+   typedef std::random_access_iterator_tag   iterator_category;
+   typedef typename boost::move_detail::make_unsigned<difference_type>::type size_type;
+};
+
+}} //namespace boost {  namespace movelib{
+
+#endif //#ifndef BOOST_MOVE_DETAIL_ITERATOR_TRAITS_HPP

--- a/src/boost/move/detail/meta_utils.hpp
+++ b/src/boost/move/detail/meta_utils.hpp
@@ -1,0 +1,585 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_DETAIL_META_UTILS_HPP
+#define BOOST_MOVE_DETAIL_META_UTILS_HPP
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>  //forceinline
+#include <boost/move/detail/meta_utils_core.hpp>
+#include <cstddef>   //for std::size_t
+
+//Small meta-typetraits to support move
+
+namespace boost {
+
+//Forward declare boost::rv
+template <class T> class rv;
+
+namespace move_detail {
+
+//////////////////////////////////////
+//          is_different
+//////////////////////////////////////
+template<class T, class U>
+struct is_different
+{
+   static const bool value = !is_same<T, U>::value;
+};
+
+//////////////////////////////////////
+//             apply
+//////////////////////////////////////
+template<class F, class Param>
+struct apply
+{
+   typedef typename F::template apply<Param>::type type;
+};
+
+//////////////////////////////////////
+//             bool_
+//////////////////////////////////////
+
+template< bool C_ >
+struct bool_ : integral_constant<bool, C_>
+{
+     operator bool() const { return C_; }
+   bool operator()() const { return C_; }
+};
+
+typedef bool_<true>        true_;
+typedef bool_<false>       false_;
+
+//////////////////////////////////////
+//              nat
+//////////////////////////////////////
+struct nat{};
+
+//////////////////////////////////////
+//          yes_type/no_type
+//////////////////////////////////////
+typedef char yes_type;
+
+struct no_type
+{
+   char _[2];
+};
+
+//////////////////////////////////////
+//            natify
+//////////////////////////////////////
+template <class T> struct natify{};
+
+//////////////////////////////////////
+//          remove_reference
+//////////////////////////////////////
+template<class T>
+struct remove_reference
+{
+   typedef T type;
+};
+
+template<class T>
+struct remove_reference<T&>
+{
+   typedef T type;
+};
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template<class T>
+struct remove_reference<T&&>
+{
+   typedef T type;
+};
+
+#else
+
+template<class T>
+struct remove_reference< rv<T> >
+{
+   typedef T type;
+};
+
+template<class T>
+struct remove_reference< rv<T> &>
+{
+   typedef T type;
+};
+
+template<class T>
+struct remove_reference< const rv<T> &>
+{
+   typedef T type;
+};
+
+#endif
+
+//////////////////////////////////////
+//             remove_pointer
+//////////////////////////////////////
+
+template< class T > struct remove_pointer                    { typedef T type;   };
+template< class T > struct remove_pointer<T*>                { typedef T type;   };
+template< class T > struct remove_pointer<T* const>          { typedef T type;   };
+template< class T > struct remove_pointer<T* volatile>       { typedef T type;   };
+template< class T > struct remove_pointer<T* const volatile> { typedef T type;   };
+
+//////////////////////////////////////
+//             add_pointer
+//////////////////////////////////////
+template< class T >
+struct add_pointer
+{
+   typedef typename remove_reference<T>::type* type;
+};
+
+//////////////////////////////////////
+//             add_const
+//////////////////////////////////////
+template<class T>
+struct add_const
+{
+   typedef const T type;
+};
+
+template<class T>
+struct add_const<T&>
+{
+   typedef const T& type;
+};
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template<class T>
+struct add_const<T&&>
+{
+   typedef T&& type;
+};
+
+#endif
+
+//////////////////////////////////////
+//      add_lvalue_reference
+//////////////////////////////////////
+template<class T>
+struct add_lvalue_reference
+{  typedef T& type;  };
+
+template<class T> struct add_lvalue_reference<T&>                 {  typedef T& type;  };
+template<>        struct add_lvalue_reference<void>               {  typedef void type;   };
+template<>        struct add_lvalue_reference<const void>         {  typedef const void type;  };
+template<>        struct add_lvalue_reference<volatile void>      {  typedef volatile void type;   };
+template<>        struct add_lvalue_reference<const volatile void>{  typedef const volatile void type;   };
+
+template<class T>
+struct add_const_lvalue_reference
+{
+   typedef typename remove_reference<T>::type         t_unreferenced;
+   typedef typename add_const<t_unreferenced>::type   t_unreferenced_const;
+   typedef typename add_lvalue_reference
+      <t_unreferenced_const>::type                    type;
+};
+
+//////////////////////////////////////
+//             is_lvalue_reference
+//////////////////////////////////////
+template<class T>
+struct is_lvalue_reference
+{
+    static const bool value = false;
+};
+
+template<class T>
+struct is_lvalue_reference<T&>
+{
+    static const bool value = true;
+};
+
+
+//////////////////////////////////////
+//             identity
+//////////////////////////////////////
+template <class T>
+struct identity
+{
+   typedef T type;
+   typedef typename add_const_lvalue_reference<T>::type reference;
+   reference operator()(reference t)
+   {  return t;   }
+};
+
+//////////////////////////////////////
+//          is_class_or_union
+//////////////////////////////////////
+template<class T>
+struct is_class_or_union
+{
+   struct twochar { char dummy[2]; };
+   template <class U>
+   static char is_class_or_union_tester(void(U::*)(void));
+   template <class U>
+   static twochar is_class_or_union_tester(...);
+   static const bool value = sizeof(is_class_or_union_tester<T>(0)) == sizeof(char);
+};
+
+//////////////////////////////////////
+//             addressof
+//////////////////////////////////////
+template<class T>
+struct addr_impl_ref
+{
+   T & v_;
+   BOOST_MOVE_FORCEINLINE addr_impl_ref( T & v ): v_( v ) {}
+   BOOST_MOVE_FORCEINLINE operator T& () const { return v_; }
+
+   private:
+   addr_impl_ref & operator=(const addr_impl_ref &);
+};
+
+template<class T>
+struct addressof_impl
+{
+   BOOST_MOVE_FORCEINLINE static T * f( T & v, long )
+   {
+      return reinterpret_cast<T*>(
+         &const_cast<char&>(reinterpret_cast<const volatile char &>(v)));
+   }
+
+   BOOST_MOVE_FORCEINLINE static T * f( T * v, int )
+   {  return v;  }
+};
+
+template<class T>
+BOOST_MOVE_FORCEINLINE T * addressof( T & v )
+{
+   return ::boost::move_detail::addressof_impl<T>::f
+      ( ::boost::move_detail::addr_impl_ref<T>( v ), 0 );
+}
+
+//////////////////////////////////////
+//          has_pointer_type
+//////////////////////////////////////
+template <class T>
+struct has_pointer_type
+{
+   struct two { char c[2]; };
+   template <class U> static two test(...);
+   template <class U> static char test(typename U::pointer* = 0);
+   static const bool value = sizeof(test<T>(0)) == 1;
+};
+
+//////////////////////////////////////
+//           is_convertible
+//////////////////////////////////////
+#if defined(_MSC_VER) && (_MSC_VER >= 1400)
+
+//use intrinsic since in MSVC
+//overaligned types can't go through ellipsis
+template <class T, class U>
+struct is_convertible
+{
+   static const bool value = __is_convertible_to(T, U);
+};
+
+#else
+
+template <class T, class U>
+class is_convertible
+{
+   typedef typename add_lvalue_reference<T>::type t_reference;
+   typedef char true_t;
+   class false_t { char dummy[2]; };
+   static false_t dispatch(...);
+   static true_t  dispatch(U);
+   static t_reference       trigger();
+   public:
+   static const bool value = sizeof(dispatch(trigger())) == sizeof(true_t);
+};
+
+#endif
+
+template <class T, class U, bool IsSame = is_same<T, U>::value>
+struct is_same_or_convertible
+   : is_convertible<T, U>
+{};
+
+template <class T, class U>
+struct is_same_or_convertible<T, U, true>
+{
+   static const bool value = true;
+};
+
+template<
+      bool C
+    , typename F1
+    , typename F2
+    >
+struct eval_if_c
+    : if_c<C,F1,F2>::type
+{};
+
+template<
+      typename C
+    , typename T1
+    , typename T2
+    >
+struct eval_if
+    : if_<C,T1,T2>::type
+{};
+
+
+#if defined(BOOST_GCC) && (BOOST_GCC <= 40000)
+#define BOOST_MOVE_HELPERS_RETURN_SFINAE_BROKEN
+#endif
+
+template<class T, class U, class R = void>
+struct enable_if_convertible
+   : enable_if< is_convertible<T, U>, R>
+{};
+
+template<class T, class U, class R = void>
+struct disable_if_convertible
+   : disable_if< is_convertible<T, U>, R>
+{};
+
+template<class T, class U, class R = void>
+struct enable_if_same_or_convertible
+   : enable_if< is_same_or_convertible<T, U>, R>
+{};
+
+template<class T, class U, class R = void>
+struct disable_if_same_or_convertible
+   : disable_if< is_same_or_convertible<T, U>, R>
+{};
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         and_
+//
+//////////////////////////////////////////////////////////////////////////////
+template<bool, class B = true_, class C = true_, class D = true_>
+struct and_impl
+   : and_impl<B::value, C, D>
+{};
+
+template<>
+struct and_impl<true, true_, true_, true_>
+{
+   static const bool value = true;
+};
+
+template<class B, class C, class D>
+struct and_impl<false, B, C, D>
+{
+   static const bool value = false;
+};
+
+template<class A, class B, class C = true_, class D = true_>
+struct and_
+   : and_impl<A::value, B, C, D>
+{};
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            or_
+//
+//////////////////////////////////////////////////////////////////////////////
+template<bool, class B = false_, class C = false_, class D = false_>
+struct or_impl
+   : or_impl<B::value, C, D>
+{};
+
+template<>
+struct or_impl<false, false_, false_, false_>
+{
+   static const bool value = false;
+};
+
+template<class B, class C, class D>
+struct or_impl<true, B, C, D>
+{
+   static const bool value = true;
+};
+
+template<class A, class B, class C = false_, class D = false_>
+struct or_
+   : or_impl<A::value, B, C, D>
+{};
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         not_
+//
+//////////////////////////////////////////////////////////////////////////////
+template<class T>
+struct not_
+{
+   static const bool value = !T::value;
+};
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// enable_if_and / disable_if_and / enable_if_or / disable_if_or
+//
+//////////////////////////////////////////////////////////////////////////////
+
+template<class R, class A, class B, class C = true_, class D = true_>
+struct enable_if_and
+   : enable_if_c< and_<A, B, C, D>::value, R>
+{};
+
+template<class R, class A, class B, class C = true_, class D = true_>
+struct disable_if_and
+   : disable_if_c< and_<A, B, C, D>::value, R>
+{};
+
+template<class R, class A, class B, class C = false_, class D = false_>
+struct enable_if_or
+   : enable_if_c< or_<A, B, C, D>::value, R>
+{};
+
+template<class R, class A, class B, class C = false_, class D = false_>
+struct disable_if_or
+   : disable_if_c< or_<A, B, C, D>::value, R>
+{};
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                      has_move_emulation_enabled_impl
+//
+//////////////////////////////////////////////////////////////////////////////
+template<class T>
+struct has_move_emulation_enabled_impl
+   : is_convertible< T, ::boost::rv<T>& >
+{};
+
+template<class T>
+struct has_move_emulation_enabled_impl<T&>
+{  static const bool value = false;  };
+
+template<class T>
+struct has_move_emulation_enabled_impl< ::boost::rv<T> >
+{  static const bool value = false;  };
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            is_rv_impl
+//
+//////////////////////////////////////////////////////////////////////////////
+
+template <class T>
+struct is_rv_impl
+{  static const bool value = false;  };
+
+template <class T>
+struct is_rv_impl< rv<T> >
+{  static const bool value = true;  };
+
+template <class T>
+struct is_rv_impl< const rv<T> >
+{  static const bool value = true;  };
+
+// Code from Jeffrey Lee Hellrung, many thanks
+
+template< class T >
+struct is_rvalue_reference
+{  static const bool value = false;  };
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template< class T >
+struct is_rvalue_reference< T&& >
+{  static const bool value = true;  };
+
+#else // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template< class T >
+struct is_rvalue_reference< boost::rv<T>& >
+{  static const bool value = true;  };
+
+template< class T >
+struct is_rvalue_reference< const boost::rv<T>& >
+{  static const bool value = true;  };
+
+#endif // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template< class T >
+struct add_rvalue_reference
+{ typedef T&& type; };
+
+#else // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+namespace detail_add_rvalue_reference
+{
+   template< class T
+            , bool emulation = has_move_emulation_enabled_impl<T>::value
+            , bool rv        = is_rv_impl<T>::value  >
+   struct add_rvalue_reference_impl { typedef T type; };
+
+   template< class T, bool emulation>
+   struct add_rvalue_reference_impl< T, emulation, true > { typedef T & type; };
+
+   template< class T, bool rv >
+   struct add_rvalue_reference_impl< T, true, rv > { typedef ::boost::rv<T>& type; };
+} // namespace detail_add_rvalue_reference
+
+template< class T >
+struct add_rvalue_reference
+   : detail_add_rvalue_reference::add_rvalue_reference_impl<T>
+{ };
+
+template< class T >
+struct add_rvalue_reference<T &>
+{  typedef T & type; };
+
+#endif // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+template< class T > struct remove_rvalue_reference { typedef T type; };
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+   template< class T > struct remove_rvalue_reference< T&& >                  { typedef T type; };
+#else // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+   template< class T > struct remove_rvalue_reference< rv<T> >                { typedef T type; };
+   template< class T > struct remove_rvalue_reference< const rv<T> >          { typedef T type; };
+   template< class T > struct remove_rvalue_reference< volatile rv<T> >       { typedef T type; };
+   template< class T > struct remove_rvalue_reference< const volatile rv<T> > { typedef T type; };
+   template< class T > struct remove_rvalue_reference< rv<T>& >               { typedef T type; };
+   template< class T > struct remove_rvalue_reference< const rv<T>& >         { typedef T type; };
+   template< class T > struct remove_rvalue_reference< volatile rv<T>& >      { typedef T type; };
+   template< class T > struct remove_rvalue_reference< const volatile rv<T>& >{ typedef T type; };
+#endif // #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+
+// Ideas from Boost.Move review, Jeffrey Lee Hellrung:
+//
+//- TypeTraits metafunctions is_lvalue_reference, add_lvalue_reference, and remove_lvalue_reference ?
+//  Perhaps add_reference and remove_reference can be modified so that they behave wrt emulated rvalue
+//  references the same as wrt real rvalue references, i.e., add_reference< rv<T>& > -> T& rather than
+//  rv<T>& (since T&& & -> T&).
+//
+//- Add'l TypeTraits has_[trivial_]move_{constructor,assign}...?
+//
+//- An as_lvalue(T& x) function, which amounts to an identity operation in C++0x, but strips emulated
+//  rvalue references in C++03.  This may be necessary to prevent "accidental moves".
+
+}  //namespace move_detail {
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_DETAIL_META_UTILS_HPP

--- a/src/boost/move/detail/meta_utils_core.hpp
+++ b/src/boost/move/detail/meta_utils_core.hpp
@@ -1,0 +1,132 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2015-2015.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_DETAIL_META_UTILS_CORE_HPP
+#define BOOST_MOVE_DETAIL_META_UTILS_CORE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+//Small meta-typetraits to support move
+
+namespace boost {
+namespace move_detail {
+
+//////////////////////////////////////
+//             if_c
+//////////////////////////////////////
+template<bool C, typename T1, typename T2>
+struct if_c
+{
+   typedef T1 type;
+};
+
+template<typename T1, typename T2>
+struct if_c<false,T1,T2>
+{
+   typedef T2 type;
+};
+
+//////////////////////////////////////
+//             if_
+//////////////////////////////////////
+template<typename T1, typename T2, typename T3>
+struct if_ : if_c<0 != T1::value, T2, T3>
+{};
+
+//////////////////////////////////////
+//          enable_if_c
+//////////////////////////////////////
+template <bool B, class T = void>
+struct enable_if_c
+{
+   typedef T type;
+};
+
+template <class T>
+struct enable_if_c<false, T> {};
+
+//////////////////////////////////////
+//           enable_if
+//////////////////////////////////////
+template <class Cond, class T = void>
+struct enable_if : enable_if_c<Cond::value, T> {};
+
+//////////////////////////////////////
+//          disable_if_c
+//////////////////////////////////////
+template <bool B, class T = void>
+struct disable_if_c
+   : enable_if_c<!B, T>
+{};
+
+//////////////////////////////////////
+//          disable_if
+//////////////////////////////////////
+template <class Cond, class T = void>
+struct disable_if : enable_if_c<!Cond::value, T> {};
+
+//////////////////////////////////////
+//          integral_constant
+//////////////////////////////////////
+template<class T, T v>
+struct integral_constant
+{
+   static const T value = v;
+   typedef T value_type;
+   typedef integral_constant<T, v> type;
+
+     operator T() const { return value; }
+   T operator()() const { return value; }
+};
+
+typedef integral_constant<bool, true >  true_type;
+typedef integral_constant<bool, false > false_type;
+
+
+//////////////////////////////////////
+//             is_same
+//////////////////////////////////////
+template<class T, class U>
+struct is_same
+{
+   static const bool value = false;
+};
+ 
+template<class T>
+struct is_same<T, T>
+{
+   static const bool value = true;
+};
+
+//////////////////////////////////////
+//        enable_if_same
+//////////////////////////////////////
+template <class T, class U, class R = void>
+struct enable_if_same : enable_if<is_same<T, U>, R> {};
+
+//////////////////////////////////////
+//        disable_if_same
+//////////////////////////////////////
+template <class T, class U, class R = void>
+struct disable_if_same : disable_if<is_same<T, U>, R> {};
+
+}  //namespace move_detail {
+}  //namespace boost {
+
+#endif //#ifndef BOOST_MOVE_DETAIL_META_UTILS_CORE_HPP

--- a/src/boost/move/detail/pointer_element.hpp
+++ b/src/boost/move/detail/pointer_element.hpp
@@ -1,0 +1,168 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2014-2017. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_MOVE_DETAIL_POINTER_ELEMENT_HPP
+#define BOOST_MOVE_DETAIL_POINTER_ELEMENT_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#ifndef BOOST_MOVE_DETAIL_WORKAROUND_HPP
+#include <boost/move/detail/workaround.hpp>
+#endif   //BOOST_MOVE_DETAIL_WORKAROUND_HPP
+
+namespace boost {
+namespace movelib {
+namespace detail{
+
+//////////////////////
+//struct first_param
+//////////////////////
+
+template <typename T> struct first_param
+{  typedef void type;   };
+
+#if !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+   template <template <typename, typename...> class TemplateClass, typename T, typename... Args>
+   struct first_param< TemplateClass<T, Args...> >
+   {
+      typedef T type;
+   };
+
+#else //C++03 compilers
+
+   template < template  //0arg
+               <class
+               > class TemplateClass, class T
+            >
+   struct first_param
+      < TemplateClass<T> >
+   {  typedef T type;   };
+
+   template < template  //1arg
+               <class,class
+               > class TemplateClass, class T
+            , class P0>
+   struct first_param
+      < TemplateClass<T, P0> >
+   {  typedef T type;   };
+
+   template < template  //2arg
+               <class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1>
+   struct first_param
+      < TemplateClass<T, P0, P1> >
+   {  typedef T type;   };
+
+   template < template  //3arg
+               <class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2> >
+   {  typedef T type;   };
+
+   template < template  //4arg
+               <class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3> >
+   {  typedef T type;   };
+
+   template < template  //5arg
+               <class,class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3, class P4>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3, P4> >
+   {  typedef T type;   };
+
+   template < template  //6arg
+               <class,class,class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3, class P4, class P5>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3, P4, P5> >
+   {  typedef T type;   };
+
+   template < template  //7arg
+               <class,class,class,class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3, class P4, class P5, class P6>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3, P4, P5, P6> >
+   {  typedef T type;   };
+
+   template < template  //8arg
+               <class,class,class,class,class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3, class P4, class P5, class P6, class P7>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3, P4, P5, P6, P7> >
+   {  typedef T type;   };
+
+   template < template  //9arg
+               <class,class,class,class,class,class,class,class,class,class
+               > class TemplateClass, class T
+            , class P0, class P1, class P2, class P3, class P4, class P5, class P6, class P7, class P8>
+   struct first_param
+      < TemplateClass<T, P0, P1, P2, P3, P4, P5, P6, P7, P8> >
+   {  typedef T type;   };
+
+#endif   //!defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+
+template <typename T>
+struct has_internal_pointer_element
+{
+   template <typename X>
+   static char test(int, typename X::element_type*);
+
+   template <typename X>
+   static int test(...);
+
+   static const bool value = (1 == sizeof(test<T>(0, 0)));
+};
+
+template<class Ptr, bool = has_internal_pointer_element<Ptr>::value>
+struct pointer_element_impl
+{
+   typedef typename Ptr::element_type type;
+};
+
+template<class Ptr>
+struct pointer_element_impl<Ptr, false>
+{
+   typedef typename boost::movelib::detail::first_param<Ptr>::type type;
+};
+
+}  //namespace detail{
+
+template <typename Ptr>
+struct pointer_element
+{
+   typedef typename ::boost::movelib::detail::pointer_element_impl<Ptr>::type type;
+};
+
+template <typename T>
+struct pointer_element<T*>
+{  typedef T type; };
+
+}  //namespace movelib {
+}  //namespace boost {
+
+#endif // defined(BOOST_MOVE_DETAIL_POINTER_ELEMENT_HPP)

--- a/src/boost/move/detail/std_ns_begin.hpp
+++ b/src/boost/move/detail/std_ns_begin.hpp
@@ -1,0 +1,30 @@
+#//////////////////////////////////////////////////////////////////////////////
+#//
+#// (C) Copyright Ion Gaztanaga 2015-2015.
+#// Distributed under the Boost Software License, Version 1.0.
+#// (See accompanying file LICENSE_1_0.txt or copy at
+#// http://www.boost.org/LICENSE_1_0.txt)
+#//
+#// See http://www.boost.org/libs/move for documentation.
+#//
+#//////////////////////////////////////////////////////////////////////////////
+#
+#if defined(_LIBCPP_VERSION)
+   #if defined(__clang__)
+      #define BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wc++11-extensions"
+   #endif
+   #define BOOST_MOVE_STD_NS_BEG _LIBCPP_BEGIN_NAMESPACE_STD
+   #define BOOST_MOVE_STD_NS_END _LIBCPP_END_NAMESPACE_STD
+#elif defined(BOOST_GNU_STDLIB) && defined(_GLIBCXX_BEGIN_NAMESPACE_VERSION)  //GCC >= 4.6
+   #define BOOST_MOVE_STD_NS_BEG namespace std _GLIBCXX_VISIBILITY(default) { _GLIBCXX_BEGIN_NAMESPACE_VERSION
+   #define BOOST_MOVE_STD_NS_END _GLIBCXX_END_NAMESPACE_VERSION  } // namespace
+#elif defined(BOOST_GNU_STDLIB) && defined(_GLIBCXX_BEGIN_NAMESPACE)  //GCC >= 4.2
+   #define BOOST_MOVE_STD_NS_BEG _GLIBCXX_BEGIN_NAMESPACE(std)
+   #define BOOST_MOVE_STD_NS_END _GLIBCXX_END_NAMESPACE
+#else
+   #define BOOST_MOVE_STD_NS_BEG namespace std{
+   #define BOOST_MOVE_STD_NS_END }
+#endif
+

--- a/src/boost/move/detail/std_ns_end.hpp
+++ b/src/boost/move/detail/std_ns_end.hpp
@@ -1,0 +1,14 @@
+#//////////////////////////////////////////////////////////////////////////////
+#//
+#// (C) Copyright Ion Gaztanaga 2015-2015.
+#// Distributed under the Boost Software License, Version 1.0.
+#// (See accompanying file LICENSE_1_0.txt or copy at
+#// http://www.boost.org/LICENSE_1_0.txt)
+#//
+#// See http://www.boost.org/libs/move for documentation.
+#//
+#//////////////////////////////////////////////////////////////////////////////
+#ifdef BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+   #pragma GCC diagnostic pop
+   #undef BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH
+#endif   //BOOST_MOVE_STD_NS_GCC_DIAGNOSTIC_PUSH

--- a/src/boost/move/detail/to_raw_pointer.hpp
+++ b/src/boost/move/detail/to_raw_pointer.hpp
@@ -1,0 +1,45 @@
+/////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga  2017-2017
+//
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_MOVE_DETAIL_TO_RAW_POINTER_HPP
+#define BOOST_MOVE_DETAIL_TO_RAW_POINTER_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>
+#include <boost/move/detail/pointer_element.hpp>
+
+namespace boost {
+namespace movelib {
+
+template <class T>
+BOOST_MOVE_FORCEINLINE T* to_raw_pointer(T* p)
+{  return p; }
+
+template <class Pointer>
+BOOST_MOVE_FORCEINLINE typename boost::movelib::pointer_element<Pointer>::type*
+to_raw_pointer(const Pointer &p)
+{  return ::boost::movelib::to_raw_pointer(p.operator->());  }
+
+} //namespace movelib
+} //namespace boost
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //BOOST_MOVE_DETAIL_TO_RAW_POINTER_HPP

--- a/src/boost/move/detail/type_traits.hpp
+++ b/src/boost/move/detail/type_traits.hpp
@@ -1,0 +1,1086 @@
+//////////////////////////////////////////////////////////////////////////////
+// (C) Copyright John Maddock 2000.
+// (C) Copyright Ion Gaztanaga 2005-2015.
+//
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+// The alignment and Type traits implementation comes from
+// John Maddock's TypeTraits library.
+//
+// Some other tricks come from Howard Hinnant's papers and StackOverflow replies
+//////////////////////////////////////////////////////////////////////////////
+#ifndef BOOST_MOVE_DETAIL_TYPE_TRAITS_HPP
+#define BOOST_MOVE_DETAIL_TYPE_TRAITS_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>
+
+// move/detail
+#include <boost/move/detail/meta_utils.hpp>
+// other
+#include <boost/assert.hpp>
+#include <boost/static_assert.hpp>
+// std
+#include <cstddef>
+
+//Use of Boost.TypeTraits leads to long preprocessed source code due to
+//MPL dependencies. We'll use intrinsics directly and make or own
+//simplified version of TypeTraits.
+//If someday Boost.TypeTraits dependencies are minimized, we should
+//revisit this file redirecting code to Boost.TypeTraits traits.
+
+//These traits don't care about volatile, reference or other checks
+//made by Boost.TypeTraits because no volatile or reference types
+//can be hold in Boost.Containers. This helps to avoid any Boost.TypeTraits
+//dependency.
+
+// Helper macros for builtin compiler support.
+// If your compiler has builtin support for any of the following
+// traits concepts, then redefine the appropriate macros to pick
+// up on the compiler support:
+//
+// (these should largely ignore cv-qualifiers)
+// BOOST_MOVE_IS_POD(T) should evaluate to true if T is a POD type
+// BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) should evaluate to true if "T x;" has no effect
+// BOOST_MOVE_HAS_TRIVIAL_COPY(T) should evaluate to true if T(t) <==> memcpy
+// (Note: this trait does not guarantee T is copy constructible, the copy constructor could be deleted but still be trivial)
+// BOOST_MOVE_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) should evaluate to true if T(boost::move(t)) <==> memcpy
+// BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) should evaluate to true if t = u <==> memcpy
+// (Note: this trait does not guarantee T is assignable , the copy assignmen could be deleted but still be trivial)
+// BOOST_MOVE_HAS_TRIVIAL_MOVE_ASSIGN(T) should evaluate to true if t = boost::move(u) <==> memcpy
+// BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) should evaluate to true if ~T() has no effect
+// BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T) should evaluate to true if "T x;" can not throw
+// BOOST_MOVE_HAS_NOTHROW_COPY(T) should evaluate to true if T(t) can not throw
+// BOOST_MOVE_HAS_NOTHROW_ASSIGN(T) should evaluate to true if t = u can not throw
+// BOOST_MOVE_IS_ENUM(T) should evaluate to true it t is a union type.
+//
+// The following can also be defined: when detected our implementation is greatly simplified.
+//
+// BOOST_ALIGNMENT_OF(T) should evaluate to the alignment requirements of type T.
+
+#if defined(__MSL_CPP__) && (__MSL_CPP__ >= 0x8000)
+    // Metrowerks compiler is acquiring intrinsic type traits support
+    // post version 8.  We hook into the published interface to pick up
+    // user defined specializations as well as compiler intrinsics as
+    // and when they become available:
+#   include <msl_utility>
+#   define BOOST_MOVE_IS_UNION(T) BOOST_STD_EXTENSION_NAMESPACE::is_union<T>::value
+#   define BOOST_MOVE_IS_POD(T) BOOST_STD_EXTENSION_NAMESPACE::is_POD<T>::value
+#   define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) BOOST_STD_EXTENSION_NAMESPACE::has_trivial_default_ctor<T>::value
+#   define BOOST_MOVE_HAS_TRIVIAL_COPY(T) BOOST_STD_EXTENSION_NAMESPACE::has_trivial_copy_ctor<T>::value
+#   define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) BOOST_STD_EXTENSION_NAMESPACE::has_trivial_assignment<T>::value
+#   define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) BOOST_STD_EXTENSION_NAMESPACE::has_trivial_dtor<T>::value
+#endif
+
+#if (defined(BOOST_MSVC) && defined(BOOST_MSVC_FULL_VER) && (BOOST_MSVC_FULL_VER >=140050215))\
+         || (defined(BOOST_INTEL) && defined(_MSC_VER) && (_MSC_VER >= 1500))
+#   define BOOST_MOVE_IS_UNION(T) __is_union(T)
+#   define BOOST_MOVE_IS_POD(T)                    (__is_pod(T) && __has_trivial_constructor(T))
+#   define BOOST_MOVE_IS_EMPTY(T)                  __is_empty(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T)   __has_trivial_constructor(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_COPY(T)          (__has_trivial_copy(T)|| ::boost::move_detail::is_pod<T>::value)
+#   define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T)        (__has_trivial_assign(T) || ::boost::move_detail::is_pod<T>::value)
+#   define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T)    (__has_trivial_destructor(T) || ::boost::move_detail::is_pod<T>::value)
+#   define BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T)   (__has_nothrow_constructor(T) || ::boost::move_detail::is_trivially_default_constructible<T>::value)
+#   define BOOST_MOVE_HAS_NOTHROW_COPY(T)          (__has_nothrow_copy(T) || ::boost::move_detail::is_trivially_copy_constructible<T>::value)
+#   define BOOST_MOVE_HAS_NOTHROW_ASSIGN(T)        (__has_nothrow_assign(T) || ::boost::move_detail::is_trivially_copy_assignable<T>::value)
+
+#   define BOOST_MOVE_IS_ENUM(T) __is_enum(T)
+#   if defined(_MSC_VER) && (_MSC_VER >= 1700)
+#       define BOOST_MOVE_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T)   (__has_trivial_move_constructor(T) || ::boost::move_detail::is_pod<T>::value)
+#       define BOOST_MOVE_HAS_TRIVIAL_MOVE_ASSIGN(T)        (__has_trivial_move_assign(T) || ::boost::move_detail::is_pod<T>::value)
+#   endif
+#endif
+
+#if defined(BOOST_CLANG) && defined(__has_feature)
+
+#   if __has_feature(is_union)
+#     define BOOST_MOVE_IS_UNION(T) __is_union(T)
+#   endif
+#   if (!defined(__GLIBCXX__) || (__GLIBCXX__ >= 20080306 && __GLIBCXX__ != 20080519)) && __has_feature(is_pod)
+#     define BOOST_MOVE_IS_POD(T) __is_pod(T)
+#   endif
+#   if (!defined(__GLIBCXX__) || (__GLIBCXX__ >= 20080306 && __GLIBCXX__ != 20080519)) && __has_feature(is_empty)
+#     define BOOST_MOVE_IS_EMPTY(T) __is_empty(T)
+#   endif
+#   if __has_feature(has_trivial_constructor)
+#     define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) __has_trivial_constructor(T)
+#   endif
+#   if __has_feature(has_trivial_copy)
+#     define BOOST_MOVE_HAS_TRIVIAL_COPY(T) __has_trivial_copy(T)
+#   endif
+#   if __has_feature(has_trivial_assign)
+#     define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T) )
+#   endif
+#   if __has_feature(has_trivial_destructor)
+#     define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) __has_trivial_destructor(T)
+#   endif
+#   if __has_feature(has_nothrow_constructor)
+#     define BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T) __has_nothrow_constructor(T)
+#   endif
+#   if __has_feature(has_nothrow_copy)
+#     define BOOST_MOVE_HAS_NOTHROW_COPY(T) (__has_nothrow_copy(T))
+#   endif
+#   if __has_feature(is_nothrow_copy_assignable)
+#     define BOOST_MOVE_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T))
+#   endif
+#   if __has_feature(is_enum)
+#     define BOOST_MOVE_IS_ENUM(T) __is_enum(T)
+#   endif
+#   if __has_feature(has_trivial_move_constructor)
+#     define BOOST_MOVE_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T) __has_trivial_move_constructor(T)
+#   endif
+#   if __has_feature(has_trivial_move_assign)
+#     define BOOST_MOVE_HAS_TRIVIAL_MOVE_ASSIGN(T) __has_trivial_move_assign(T)
+#   endif
+#   define BOOST_MOVE_ALIGNMENT_OF(T) __alignof(T)
+#endif
+
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 3) && !defined(__GCCXML__))) && !defined(BOOST_CLANG)
+
+#ifdef BOOST_INTEL
+#  define BOOST_MOVE_INTEL_TT_OPTS || ::boost::move_detail::is_pod<T>::value
+#else
+#  define BOOST_MOVE_INTEL_TT_OPTS
+#endif
+
+#   define BOOST_MOVE_IS_UNION(T) __is_union(T)
+#   define BOOST_MOVE_IS_POD(T) __is_pod(T)
+#   define BOOST_MOVE_IS_EMPTY(T) __is_empty(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) ((__has_trivial_constructor(T) BOOST_MOVE_INTEL_TT_OPTS))
+#   define BOOST_MOVE_HAS_TRIVIAL_COPY(T) ((__has_trivial_copy(T) BOOST_MOVE_INTEL_TT_OPTS))
+#   define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) ((__has_trivial_assign(T) BOOST_MOVE_INTEL_TT_OPTS) )
+#   define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T) BOOST_MOVE_INTEL_TT_OPTS)
+#   define BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T) (__has_nothrow_constructor(T) BOOST_MOVE_INTEL_TT_OPTS)
+#   define BOOST_MOVE_HAS_NOTHROW_COPY(T) ((__has_nothrow_copy(T) BOOST_MOVE_INTEL_TT_OPTS))
+#   define BOOST_MOVE_HAS_NOTHROW_ASSIGN(T) ((__has_nothrow_assign(T) BOOST_MOVE_INTEL_TT_OPTS))
+
+#   define BOOST_MOVE_IS_ENUM(T) __is_enum(T)
+#   if (!defined(unix) && !defined(__unix__)) || defined(__LP64__)
+      // GCC sometimes lies about alignment requirements
+      // of type double on 32-bit unix platforms, use the
+      // old implementation instead in that case:
+#     define BOOST_MOVE_ALIGNMENT_OF(T) __alignof__(T)
+#   endif
+#endif
+
+#if defined(__ghs__) && (__GHS_VERSION_NUMBER >= 600)
+
+#   define BOOST_MOVE_IS_UNION(T) __is_union(T)
+#   define BOOST_MOVE_IS_POD(T) __is_pod(T)
+#   define BOOST_MOVE_IS_EMPTY(T) __is_empty(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) __has_trivial_constructor(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_COPY(T) (__has_trivial_copy(T))
+#   define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T))
+#   define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) __has_trivial_destructor(T)
+#   define BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T) __has_nothrow_constructor(T)
+#   define BOOST_MOVE_HAS_NOTHROW_COPY(T) (__has_nothrow_copy(T))
+#   define BOOST_MOVE_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T))
+
+#   define BOOST_MOVE_IS_ENUM(T) __is_enum(T)
+#   define BOOST_MOVE_ALIGNMENT_OF(T) __alignof__(T)
+#endif
+
+# if defined(__CODEGEARC__)
+#   define BOOST_MOVE_IS_UNION(T) __is_union(T)
+#   define BOOST_MOVE_IS_POD(T) __is_pod(T)
+#   define BOOST_MOVE_IS_EMPTY(T) __is_empty(T)
+#   define BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T) (__has_trivial_default_constructor(T))
+#   define BOOST_MOVE_HAS_TRIVIAL_COPY(T) (__has_trivial_copy_constructor(T))
+#   define BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T) (__has_trivial_assign(T))
+#   define BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T) (__has_trivial_destructor(T))
+#   define BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T) (__has_nothrow_default_constructor(T))
+#   define BOOST_MOVE_HAS_NOTHROW_COPY(T) (__has_nothrow_copy_constructor(T))
+#   define BOOST_MOVE_HAS_NOTHROW_ASSIGN(T) (__has_nothrow_assign(T))
+
+#   define BOOST_MOVE_IS_ENUM(T) __is_enum(T)
+#   define BOOST_MOVE_ALIGNMENT_OF(T) alignof(T)
+
+#endif
+
+//Fallback definitions
+
+#ifdef BOOST_MOVE_IS_UNION
+   #define BOOST_MOVE_IS_UNION_IMPL(T) BOOST_MOVE_IS_UNION(T)
+#else
+   #define BOOST_MOVE_IS_UNION_IMPL(T) false
+#endif
+
+#ifdef BOOST_MOVE_IS_POD
+   //in some compilers the intrinsic is limited to class types so add scalar and void
+   #define BOOST_MOVE_IS_POD_IMPL(T) (::boost::move_detail::is_scalar<T>::value ||\
+                                      ::boost::move_detail::is_void<T>::value   ||\
+                                       BOOST_MOVE_IS_POD(T))
+#else
+   #define BOOST_MOVE_IS_POD_IMPL(T) \
+      (::boost::move_detail::is_scalar<T>::value || ::boost::move_detail::is_void<T>::value)
+#endif
+
+#ifdef BOOST_MOVE_IS_EMPTY
+   #define BOOST_MOVE_IS_EMPTY_IMPL(T) BOOST_MOVE_IS_EMPTY(T)
+#else
+   #define BOOST_MOVE_IS_EMPTY_IMPL(T)    ::boost::move_detail::is_empty_nonintrinsic<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_COPY
+   #define BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value ||\
+                                                          (::boost::move_detail::is_copy_constructible<T>::value &&\
+                                                           BOOST_MOVE_HAS_TRIVIAL_COPY(T))
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR
+   #define BOOST_MOVE_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T)  BOOST_MOVE_HAS_TRIVIAL_CONSTRUCTOR(T)
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T)  ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_MOVE_CONSTRUCTOR
+   #define BOOST_MOVE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE(T)   BOOST_MOVE_HAS_TRIVIAL_MOVE_CONSTRUCTOR(T)
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_ASSIGN
+   #define BOOST_MOVE_IS_TRIVIALLY_COPY_ASSIGNABLE(T) ::boost::move_detail::is_pod<T>::value ||\
+                                                      ( ::boost::move_detail::is_copy_assignable<T>::value &&\
+                                                         BOOST_MOVE_HAS_TRIVIAL_ASSIGN(T))
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_COPY_ASSIGNABLE(T) ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_MOVE_ASSIGN
+   #define BOOST_MOVE_IS_TRIVIALLY_MOVE_ASSIGNABLE(T)  BOOST_MOVE_HAS_TRIVIAL_MOVE_ASSIGN(T)
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_MOVE_ASSIGNABLE(T)  ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR
+   #define BOOST_MOVE_IS_TRIVIALLY_DESTRUCTIBLE(T)   BOOST_MOVE_HAS_TRIVIAL_DESTRUCTOR(T)
+#else
+   #define BOOST_MOVE_IS_TRIVIALLY_DESTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR
+   #define BOOST_MOVE_IS_NOTHROW_DEFAULT_CONSTRUCTIBLE(T)  BOOST_MOVE_HAS_NOTHROW_CONSTRUCTOR(T)
+#else
+   #define BOOST_MOVE_IS_NOTHROW_DEFAULT_CONSTRUCTIBLE(T)  ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_NOTHROW_COPY
+   #define BOOST_MOVE_IS_NOTHROW_COPY_CONSTRUCTIBLE(T)   BOOST_MOVE_HAS_NOTHROW_COPY(T)
+#else
+   #define BOOST_MOVE_IS_NOTHROW_COPY_CONSTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_NOTHROW_MOVE
+   #define BOOST_MOVE_IS_NOTHROW_MOVE_CONSTRUCTIBLE(T)   BOOST_MOVE_HAS_NOTHROW_MOVE(T)
+#else
+   #define BOOST_MOVE_IS_NOTHROW_MOVE_CONSTRUCTIBLE(T)   ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_NOTHROW_ASSIGN
+   #define BOOST_MOVE_IS_NOTHROW_COPY_ASSIGNABLE(T) BOOST_MOVE_HAS_NOTHROW_ASSIGN(T)
+#else
+   #define BOOST_MOVE_IS_NOTHROW_COPY_ASSIGNABLE(T) ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_HAS_NOTHROW_MOVE_ASSIGN
+   #define BOOST_MOVE_IS_NOTHROW_MOVE_ASSIGNABLE(T) BOOST_MOVE_HAS_NOTHROW_MOVE_ASSIGN(T)
+#else
+   #define BOOST_MOVE_IS_NOTHROW_MOVE_ASSIGNABLE(T) ::boost::move_detail::is_pod<T>::value
+#endif
+
+#ifdef BOOST_MOVE_IS_ENUM
+   #define BOOST_MOVE_IS_ENUM_IMPL(T)   BOOST_MOVE_IS_ENUM(T)
+#else
+   #define BOOST_MOVE_IS_ENUM_IMPL(T)   ::boost::move_detail::is_enum_nonintrinsic<T>::value
+#endif
+
+namespace boost {
+namespace move_detail {
+
+//////////////////////////
+//    is_reference
+//////////////////////////
+template<class T>
+struct is_reference
+{  static const bool value = false; };
+
+template<class T>
+struct is_reference<T&>
+{  static const bool value = true; };
+
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+template<class T>
+struct is_reference<T&&>
+{  static const bool value = true; };
+#endif
+
+//////////////////////////
+//    is_pointer
+//////////////////////////
+template<class T>
+struct is_pointer
+{  static const bool value = false; };
+
+template<class T>
+struct is_pointer<T*>
+{  static const bool value = true; };
+
+//////////////////////////
+//       is_const
+//////////////////////////
+template<class T>
+struct is_const
+{  static const bool value = false; };
+
+template<class T>
+struct is_const<const T>
+{  static const bool value = true; };
+
+//////////////////////////
+//       unvoid_ref
+//////////////////////////
+template <typename T> struct unvoid_ref : add_lvalue_reference<T>{};
+template <> struct unvoid_ref<void>                { typedef unvoid_ref & type; };
+template <> struct unvoid_ref<const void>          { typedef unvoid_ref & type; };
+template <> struct unvoid_ref<volatile void>       { typedef unvoid_ref & type; };
+template <> struct unvoid_ref<const volatile void> { typedef unvoid_ref & type; };
+
+template <typename T>
+struct add_reference : add_lvalue_reference<T>
+{};
+
+//////////////////////////
+//    add_const_reference
+//////////////////////////
+template <class T>
+struct add_const_reference
+{  typedef const T &type;   };
+
+template <class T>
+struct add_const_reference<T&>
+{  typedef T& type;   };
+
+//////////////////////////
+//    add_const_if_c
+//////////////////////////
+template<class T, bool Add>
+struct add_const_if_c
+   : if_c<Add, typename add_const<T>::type, T>
+{};
+
+//////////////////////////
+//    remove_const
+//////////////////////////
+template<class T>
+struct remove_const
+{  typedef T type;   };
+
+template<class T>
+struct remove_const< const T>
+{  typedef T type;   };
+
+//////////////////////////
+//    remove_cv
+//////////////////////////
+template<typename T> struct remove_cv                    {  typedef T type;   };
+template<typename T> struct remove_cv<const T>           {  typedef T type;   };
+template<typename T> struct remove_cv<const volatile T>  {  typedef T type;   };
+template<typename T> struct remove_cv<volatile T>        {  typedef T type;   };
+
+//////////////////////////
+//    make_unsigned
+//////////////////////////
+template <class T>
+struct make_unsigned_impl                                         {  typedef T type;   };
+template <> struct make_unsigned_impl<signed char>                {  typedef unsigned char  type; };
+template <> struct make_unsigned_impl<signed short>               {  typedef unsigned short type; };
+template <> struct make_unsigned_impl<signed int>                 {  typedef unsigned int   type; };
+template <> struct make_unsigned_impl<signed long>                {  typedef unsigned long  type; };
+#ifdef BOOST_HAS_LONG_LONG
+template <> struct make_unsigned_impl< ::boost::long_long_type >  {  typedef ::boost::ulong_long_type type; };
+#endif
+
+template <class T>
+struct make_unsigned
+   : make_unsigned_impl<typename remove_cv<T>::type>
+{};
+
+//////////////////////////
+//    is_floating_point
+//////////////////////////
+template<class T> struct is_floating_point_cv               {  static const bool value = false; };
+template<>        struct is_floating_point_cv<float>        {  static const bool value = true; };
+template<>        struct is_floating_point_cv<double>       {  static const bool value = true; };
+template<>        struct is_floating_point_cv<long double>  {  static const bool value = true; };
+
+template<class T>
+struct is_floating_point
+   : is_floating_point_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////
+//    is_integral
+//////////////////////////
+template<class T> struct is_integral_cv                    {  static const bool value = false; };
+template<> struct is_integral_cv<                     bool>{  static const bool value = true; };
+template<> struct is_integral_cv<                     char>{  static const bool value = true; };
+template<> struct is_integral_cv<            unsigned char>{  static const bool value = true; };
+template<> struct is_integral_cv<              signed char>{  static const bool value = true; };
+#ifndef BOOST_NO_CXX11_CHAR16_T
+template<> struct is_integral_cv<                 char16_t>{  static const bool value = true; };
+#endif
+#ifndef BOOST_NO_CXX11_CHAR32_T
+template<> struct is_integral_cv<                 char32_t>{  static const bool value = true; };
+#endif
+#ifndef BOOST_NO_INTRINSIC_WCHAR_T
+template<> struct is_integral_cv<                  wchar_t>{  static const bool value = true; };
+#endif
+template<> struct is_integral_cv<                    short>{  static const bool value = true; };
+template<> struct is_integral_cv<           unsigned short>{  static const bool value = true; };
+template<> struct is_integral_cv<                      int>{  static const bool value = true; };
+template<> struct is_integral_cv<             unsigned int>{  static const bool value = true; };
+template<> struct is_integral_cv<                     long>{  static const bool value = true; };
+template<> struct is_integral_cv<            unsigned long>{  static const bool value = true; };
+#ifdef BOOST_HAS_LONG_LONG
+template<> struct is_integral_cv< ::boost:: long_long_type>{  static const bool value = true; };
+template<> struct is_integral_cv< ::boost::ulong_long_type>{  static const bool value = true; };
+#endif
+
+template<class T>
+struct is_integral
+   : public is_integral_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////////////////
+//          remove_all_extents
+//////////////////////////////////////
+template <class T>
+struct remove_all_extents
+{  typedef T type;};
+
+template <class T>
+struct remove_all_extents<T[]>
+{  typedef typename remove_all_extents<T>::type type; };
+
+template <class T, std::size_t N>
+struct remove_all_extents<T[N]>
+{  typedef typename remove_all_extents<T>::type type;};
+
+//////////////////////////
+//    is_scalar
+//////////////////////////
+template<class T>
+struct is_scalar
+{  static const bool value = is_integral<T>::value || is_floating_point<T>::value; };
+
+//////////////////////////
+//       is_void
+//////////////////////////
+template<class T>
+struct is_void_cv
+{  static const bool value = false; };
+
+template<>
+struct is_void_cv<void>
+{  static const bool value = true; };
+
+template<class T>
+struct is_void
+   : is_void_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////////////////
+//          is_array
+//////////////////////////////////////
+template<class T>
+struct is_array
+{  static const bool value = false; };
+
+template<class T>
+struct is_array<T[]>
+{  static const bool value = true;  };
+
+template<class T, std::size_t N>
+struct is_array<T[N]>
+{  static const bool value = true;  };
+
+//////////////////////////////////////
+//           is_member_pointer
+//////////////////////////////////////
+template <class T>         struct is_member_pointer_cv         {  static const bool value = false; };
+template <class T, class U>struct is_member_pointer_cv<T U::*> {  static const bool value = true; };
+
+template <class T>
+struct is_member_pointer
+    : is_member_pointer_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////////////////
+//          is_nullptr_t
+//////////////////////////////////////
+template <class T>
+struct is_nullptr_t_cv
+{  static const bool value = false; };
+
+#if !defined(BOOST_NO_CXX11_NULLPTR)
+template <>
+struct is_nullptr_t_cv
+   #if !defined(BOOST_NO_CXX11_DECLTYPE)
+   <decltype(nullptr)>
+   #else
+   <std::nullptr_t>
+   #endif
+{  static const bool value = true; };
+#endif
+
+template <class T>
+struct is_nullptr_t
+   : is_nullptr_t_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////////////////
+//          is_function
+//////////////////////////////////////
+//Inspired by libc++, thanks to Howard Hinnant
+//For a function to pointer an lvalue of function type T can be implicitly converted to a prvalue
+//pointer to that function. This does not apply to non-static member functions because lvalues
+//that refer to non-static member functions do not exist.
+template <class T>
+struct is_reference_convertible_to_pointer
+{
+   struct twochar { char dummy[2]; };
+   template <class U> static char    test(U*);
+   template <class U> static twochar test(...);
+   static T& source();
+   static const bool value = sizeof(char) == sizeof(test<T>(source()));
+};
+//Filter out:
+// - class types that might have implicit conversions
+// - void (to avoid forming a reference to void later)
+// - references (e.g.: filtering reference to functions)
+// - nullptr_t (convertible to pointer)
+template < class T
+         , bool Filter = is_class_or_union<T>::value  ||
+                         is_void<T>::value            ||
+                         is_reference<T>::value       ||
+                         is_nullptr_t<T>::value       >
+struct is_function_impl
+{  static const bool value = is_reference_convertible_to_pointer<T>::value; };
+
+template <class T>
+struct is_function_impl<T, true>
+{  static const bool value = false; };
+
+template <class T>
+struct is_function
+   : is_function_impl<T>
+{};
+
+//////////////////////////////////////
+//       is_union
+//////////////////////////////////////
+template<class T>
+struct is_union_noextents_cv
+{  static const bool value = BOOST_MOVE_IS_UNION_IMPL(T); };
+
+template<class T>
+struct is_union
+   : is_union_noextents_cv<typename remove_cv<typename remove_all_extents<T>::type>::type>
+{};
+
+//////////////////////////////////////
+//             is_class
+//////////////////////////////////////
+template <class T>
+struct is_class
+{
+   static const bool value = is_class_or_union<T>::value && ! is_union<T>::value;
+};
+
+
+//////////////////////////////////////
+//             is_arithmetic
+//////////////////////////////////////
+template <class T>
+struct is_arithmetic
+{
+   static const bool value = is_floating_point<T>::value ||
+                             is_integral<T>::value;
+};
+
+//////////////////////////////////////
+//    is_member_function_pointer
+//////////////////////////////////////
+template <class T>
+struct is_member_function_pointer_cv
+{
+   static const bool value = false;
+};
+
+template <class T, class C>
+struct is_member_function_pointer_cv<T C::*>
+   : is_function<T>
+{};
+
+template <class T>
+struct is_member_function_pointer
+    : is_member_function_pointer_cv<typename remove_cv<T>::type>
+{};
+
+//////////////////////////////////////
+//             is_enum
+//////////////////////////////////////
+#if !defined(BOOST_MOVE_IS_ENUM)
+//Based on (http://howardhinnant.github.io/TypeHiearchy.pdf)
+template <class T>
+struct is_enum_nonintrinsic
+{
+   static const bool value =  !is_arithmetic<T>::value     &&
+                              !is_reference<T>::value      &&
+                              !is_class_or_union<T>::value &&
+                              !is_array<T>::value          &&
+                              !is_void<T>::value           &&
+                              !is_nullptr_t<T>::value      &&
+                              !is_member_pointer<T>::value &&
+                              !is_pointer<T>::value        &&
+                              !is_function<T>::value;
+};
+#endif
+
+template <class T>
+struct is_enum
+{  static const bool value = BOOST_MOVE_IS_ENUM_IMPL(T);  };
+
+//////////////////////////////////////
+//       is_pod
+//////////////////////////////////////
+template<class T>
+struct is_pod_noextents_cv  //for non-c++11 compilers, a safe fallback
+{  static const bool value = BOOST_MOVE_IS_POD_IMPL(T); };
+
+template<class T>
+struct is_pod
+   : is_pod_noextents_cv<typename remove_cv<typename remove_all_extents<T>::type>::type>
+{};
+
+//////////////////////////////////////
+//             is_empty
+//////////////////////////////////////
+#if !defined(BOOST_MOVE_IS_EMPTY)
+
+template <typename T>
+struct empty_helper_t1 : public T
+{
+   empty_helper_t1();  // hh compiler bug workaround
+   int i[256];
+   private:
+
+   empty_helper_t1(const empty_helper_t1&);
+   empty_helper_t1& operator=(const empty_helper_t1&);
+};
+
+struct empty_helper_t2 { int i[256]; };
+
+template <typename T, bool IsClass = is_class<T>::value >
+struct is_empty_nonintrinsic
+{
+   static const bool value = false;
+};
+
+template <typename T>
+struct is_empty_nonintrinsic<T, true>
+{
+   static const bool value = sizeof(empty_helper_t1<T>) == sizeof(empty_helper_t2);
+};
+#endif
+
+template <class T>
+struct is_empty
+{  static const bool value = BOOST_MOVE_IS_EMPTY_IMPL(T);  };
+
+
+template<class T>
+struct has_boost_move_no_copy_constructor_or_assign_type
+{
+   template <class U>
+   static yes_type test(typename U::boost_move_no_copy_constructor_or_assign*);
+
+   template <class U>
+   static no_type test(...);
+
+   static const bool value = sizeof(test<T>(0)) == sizeof(yes_type);
+};
+
+//////////////////////////////////////
+//       is_copy_constructible
+//////////////////////////////////////
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS) && !defined(BOOST_NO_CXX11_DECLTYPE) \
+   && !defined(BOOST_INTEL_CXX_VERSION) && \
+      !(defined(BOOST_MSVC) && _MSC_VER == 1800)
+#define BOOST_MOVE_TT_CXX11_IS_COPY_CONSTRUCTIBLE
+#endif
+
+template<class T>
+struct is_copy_constructible
+{
+   // Intel compiler has problems with SFINAE for copy constructors and deleted functions:
+   //
+   // error: function *function_name* cannot be referenced -- it is a deleted function
+   // static yes_type test(U&, decltype(U(boost::declval<U&>()))* = 0);
+   //                                                        ^ 
+   // MSVC 12.0 (Visual 2013) has problems when the copy constructor has been deleted. See:
+   // https://connect.microsoft.com/VisualStudio/feedback/details/800328/std-is-copy-constructible-is-broken
+   #if defined(BOOST_MOVE_TT_CXX11_IS_COPY_CONSTRUCTIBLE)
+      template<class U> static typename add_reference<U>::type source();
+      static no_type test(...);
+      #ifdef BOOST_NO_CXX11_DECLTYPE
+         template <class U>
+         static yes_type test(U&, bool_<sizeof(U(source<U>()))>* = 0);
+      #else
+         template <class U>
+         static yes_type test(U&, decltype(U(source<U>()))* = 0);
+      #endif
+      static const bool value = sizeof(test(source<T>())) == sizeof(yes_type);
+   #else
+   static const bool value = !has_boost_move_no_copy_constructor_or_assign_type<T>::value;
+   #endif
+};
+
+
+//////////////////////////////////////
+//       is_copy_assignable
+//////////////////////////////////////
+#if !defined(BOOST_NO_CXX11_DELETED_FUNCTIONS) && !defined(BOOST_NO_CXX11_DECLTYPE) \
+   && !defined(BOOST_INTEL_CXX_VERSION) && \
+      !(defined(BOOST_MSVC) && _MSC_VER == 1800)
+#define BOOST_MOVE_TT_CXX11_IS_COPY_ASSIGNABLE
+#endif
+
+template <class T>
+struct is_copy_assignable
+{
+// Intel compiler has problems with SFINAE for copy constructors and deleted functions:
+//
+// error: function *function_name* cannot be referenced -- it is a deleted function
+// static boost::type_traits::yes_type test(T1&, decltype(T1(boost::declval<T1&>()))* = 0);
+//                                                        ^ 
+//
+// MSVC 12.0 (Visual 2013) has problems when the copy constructor has been deleted. See:
+// https://connect.microsoft.com/VisualStudio/feedback/details/800328/std-is-copy-constructible-is-broken
+#if defined(BOOST_MOVE_TT_CXX11_IS_COPY_ASSIGNABLE)
+   typedef char yes_type;
+   struct no_type { char dummy[2]; };
+   
+   template <class U>   static typename add_reference<U>::type source();
+   template <class U>   static decltype(source<U&>() = source<const U&>(), yes_type() ) test(int);
+   template <class>     static no_type test(...);
+
+   static const bool value = sizeof(test<T>(0)) == sizeof(yes_type);
+#else
+   static const bool value = !has_boost_move_no_copy_constructor_or_assign_type<T>::value;
+#endif
+};
+
+//////////////////////////////////////
+//       is_trivially_destructible
+//////////////////////////////////////
+template<class T>
+struct is_trivially_destructible
+{  static const bool value = BOOST_MOVE_IS_TRIVIALLY_DESTRUCTIBLE(T); };
+
+//////////////////////////////////////
+//       is_trivially_default_constructible
+//////////////////////////////////////
+template<class T>
+struct is_trivially_default_constructible
+{  static const bool value = BOOST_MOVE_IS_TRIVIALLY_DEFAULT_CONSTRUCTIBLE(T); };
+
+//////////////////////////////////////
+//       is_trivially_copy_constructible
+//////////////////////////////////////
+template<class T>
+struct is_trivially_copy_constructible
+{
+   //In several compilers BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE return true even with
+   //deleted copy constructors so make sure the type is copy constructible.
+   static const bool value = BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE(T);
+};
+
+//////////////////////////////////////
+//       is_trivially_move_constructible
+//////////////////////////////////////
+template<class T>
+struct is_trivially_move_constructible
+{ static const bool value = BOOST_MOVE_IS_TRIVIALLY_MOVE_CONSTRUCTIBLE(T); };
+
+//////////////////////////////////////
+//       is_trivially_copy_assignable
+//////////////////////////////////////
+template<class T>
+struct is_trivially_copy_assignable
+{
+   //In several compilers BOOST_MOVE_IS_TRIVIALLY_COPY_CONSTRUCTIBLE return true even with
+   //deleted copy constructors so make sure the type is copy constructible.
+   static const bool value = BOOST_MOVE_IS_TRIVIALLY_COPY_ASSIGNABLE(T);
+};                             
+
+//////////////////////////////////////
+//       is_trivially_move_assignable
+//////////////////////////////////////
+template<class T>
+struct is_trivially_move_assignable
+{  static const bool value = BOOST_MOVE_IS_TRIVIALLY_MOVE_ASSIGNABLE(T);  };
+
+//////////////////////////////////////
+//       is_nothrow_default_constructible
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_default_constructible
+   : is_pod<T>
+{  static const bool value = BOOST_MOVE_IS_NOTHROW_DEFAULT_CONSTRUCTIBLE(T);  };
+
+//////////////////////////////////////
+//    is_nothrow_copy_constructible
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_copy_constructible
+{  static const bool value = BOOST_MOVE_IS_NOTHROW_COPY_CONSTRUCTIBLE(T);  };
+
+//////////////////////////////////////
+//    is_nothrow_move_constructible
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_move_constructible
+{  static const bool value = BOOST_MOVE_IS_NOTHROW_MOVE_CONSTRUCTIBLE(T);  };
+
+//////////////////////////////////////
+//       is_nothrow_copy_assignable
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_copy_assignable
+{  static const bool value = BOOST_MOVE_IS_NOTHROW_COPY_ASSIGNABLE(T);  };
+
+//////////////////////////////////////
+//    is_nothrow_move_assignable
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_move_assignable
+{  static const bool value = BOOST_MOVE_IS_NOTHROW_MOVE_ASSIGNABLE(T);  };
+
+//////////////////////////////////////
+//    is_nothrow_swappable
+//////////////////////////////////////
+template<class T>
+struct is_nothrow_swappable
+{
+   static const bool value = is_empty<T>::value || is_pod<T>::value;
+};
+
+//////////////////////////////////////
+//       alignment_of
+//////////////////////////////////////
+template <typename T>
+struct alignment_of_hack
+{
+   T t1;
+   char c;
+   T t2;
+   alignment_of_hack();
+};
+
+template <unsigned A, unsigned S>
+struct alignment_logic
+{  static const std::size_t value = A < S ? A : S; };
+
+template< typename T >
+struct alignment_of_impl
+#if defined(BOOST_MSVC) && (BOOST_MSVC >= 1400)
+    // With MSVC both the native __alignof operator
+    // and our own logic gets things wrong from time to time :-(
+    // Using a combination of the two seems to make the most of a bad job:
+   : alignment_logic< sizeof(alignment_of_hack<T>) - 2*sizeof(T), __alignof(T)>
+{};
+#elif !defined(BOOST_MOVE_ALIGNMENT_OF)
+   : alignment_logic< sizeof(alignment_of_hack<T>) - 2*sizeof(T), sizeof(T)>
+{};
+#else
+{  static const std::size_t value = BOOST_MOVE_ALIGNMENT_OF(T);  };
+#endif
+
+template< typename T >
+struct alignment_of
+   : alignment_of_impl<T>
+{};
+
+class alignment_dummy;
+typedef void (*function_ptr)();
+typedef int (alignment_dummy::*member_ptr);
+typedef int (alignment_dummy::*member_function_ptr)();
+struct alignment_struct
+{  long double dummy[4];  };
+
+/////////////////////////////
+//    max_align_t
+/////////////////////////////
+//This is not standard, but should work with all compilers
+union max_align
+{
+   char        char_;
+   short       short_;
+   int         int_;
+   long        long_;
+   #ifdef BOOST_HAS_LONG_LONG
+   ::boost::long_long_type   long_long_;
+   #endif
+   float       float_;
+   double      double_;
+   void *      void_ptr_;
+   long double long_double_[4];
+   alignment_dummy *unknown_class_ptr_;
+   function_ptr function_ptr_;
+   member_function_ptr member_function_ptr_;
+   alignment_struct alignment_struct_;
+};
+
+typedef union max_align max_align_t;
+
+/////////////////////////////
+//    aligned_storage
+/////////////////////////////
+
+#if !defined(BOOST_NO_ALIGNMENT)
+
+template<std::size_t Len, std::size_t Align>
+struct aligned_struct;
+
+#define BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(A)\
+template<std::size_t Len>\
+struct BOOST_ALIGNMENT(A) aligned_struct<Len, A>\
+{\
+   char data[Len];\
+};\
+//
+
+//Up to 4K alignment (typical page size)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x1)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x2)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x4)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x8)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x10)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x20)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x40)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x80)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x100)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x200)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x400)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x800)
+BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT(0x1000)
+
+#undef BOOST_MOVE_ALIGNED_STORAGE_WITH_BOOST_ALIGNMENT
+
+// Workaround for bogus [-Wignored-attributes] warning on GCC 6.x/7.x: don't use a type that "directly" carries the alignment attribute.
+// See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=82270
+template<std::size_t Len, std::size_t Align>
+union aligned_struct_wrapper
+{
+   aligned_struct<Len, Align> aligner;
+   char data[sizeof(aligned_struct<Len, Align>)];
+};
+
+template<std::size_t Len, std::size_t Align>
+struct aligned_storage_impl
+{
+   typedef aligned_struct_wrapper<Len, Align> type;
+};
+
+#else //BOOST_NO_ALIGNMENT
+
+template<class T, std::size_t Len>
+union aligned_union
+{   
+   T aligner;
+   char data[Len];
+};
+
+template<std::size_t Len, std::size_t Align, class T, bool Ok>
+struct aligned_next;
+
+template<std::size_t Len, std::size_t Align, class T>
+struct aligned_next<Len, Align, T, true>
+{
+   BOOST_STATIC_ASSERT((alignment_of<T>::value == Align));
+   typedef aligned_union<T, Len> type;
+};
+
+//End of search defaults to max_align_t
+template<std::size_t Len, std::size_t Align>
+struct aligned_next<Len, Align, max_align_t, false>
+{   typedef aligned_union<max_align_t, Len> type;   };
+
+//Now define a search list through types
+#define BOOST_MOVE_ALIGNED_NEXT_STEP(TYPE, NEXT_TYPE)\
+   template<std::size_t Len, std::size_t Align>\
+   struct aligned_next<Len, Align, TYPE, false>\
+      : aligned_next<Len, Align, NEXT_TYPE, Align == alignment_of<NEXT_TYPE>::value>\
+   {};\
+   //
+   BOOST_MOVE_ALIGNED_NEXT_STEP(long double, max_align_t)
+   BOOST_MOVE_ALIGNED_NEXT_STEP(double, long double)
+   #ifdef BOOST_HAS_LONG_LONG
+      BOOST_MOVE_ALIGNED_NEXT_STEP(::boost::long_long_type, double)
+      BOOST_MOVE_ALIGNED_NEXT_STEP(long, ::boost::long_long_type)
+   #else
+      BOOST_MOVE_ALIGNED_NEXT_STEP(long, double)
+   #endif
+   BOOST_MOVE_ALIGNED_NEXT_STEP(int, long)
+   BOOST_MOVE_ALIGNED_NEXT_STEP(short, int)
+   BOOST_MOVE_ALIGNED_NEXT_STEP(char, short)
+#undef BOOST_MOVE_ALIGNED_NEXT_STEP
+
+template<std::size_t Len, std::size_t Align>
+struct aligned_storage_impl
+   : aligned_next<Len, Align, char, Align == alignment_of<char>::value>
+{};
+
+#endif
+
+template<std::size_t Len, std::size_t Align = alignment_of<max_align_t>::value>
+struct aligned_storage
+{
+   //Sanity checks for input parameters
+   BOOST_STATIC_ASSERT(Align > 0);
+
+   //Sanity checks for output type
+   typedef typename aligned_storage_impl<Len ? Len : 1, Align>::type type;
+   static const std::size_t value = alignment_of<type>::value;
+   BOOST_STATIC_ASSERT(value >= Align);
+   BOOST_STATIC_ASSERT((value % Align) == 0);
+
+   //Just in case someone instantiates aligned_storage
+   //instead of aligned_storage::type (typical error).
+   private:
+   aligned_storage();
+};
+
+}  //namespace move_detail {
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif   //#ifndef BOOST_MOVE_DETAIL_TYPE_TRAITS_HPP

--- a/src/boost/move/detail/workaround.hpp
+++ b/src/boost/move/detail/workaround.hpp
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2014-2014. Distributed under the Boost
+// Software License, Version 1.0. (See accompanying file
+// LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/interprocess for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef BOOST_MOVE_DETAIL_WORKAROUND_HPP
+#define BOOST_MOVE_DETAIL_WORKAROUND_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#if    !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_NO_CXX11_VARIADIC_TEMPLATES)
+   #define BOOST_MOVE_PERFECT_FORWARDING
+#endif
+
+#if defined(__has_feature)
+   #define BOOST_MOVE_HAS_FEATURE __has_feature
+#else
+   #define BOOST_MOVE_HAS_FEATURE(x) 0
+#endif
+
+#if BOOST_MOVE_HAS_FEATURE(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+   #define BOOST_MOVE_ADDRESS_SANITIZER_ON
+#endif
+
+//Macros for documentation purposes. For code, expands to the argument
+#define BOOST_MOVE_IMPDEF(TYPE) TYPE
+#define BOOST_MOVE_SEEDOC(TYPE) TYPE
+#define BOOST_MOVE_DOC0PTR(TYPE) TYPE
+#define BOOST_MOVE_DOC1ST(TYPE1, TYPE2) TYPE2
+#define BOOST_MOVE_I ,
+#define BOOST_MOVE_DOCIGN(T1) T1
+
+#if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ < 5) && !defined(__clang__)
+   //Pre-standard rvalue binding rules
+   #define BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+#elif defined(_MSC_VER) && (_MSC_VER == 1600)
+   //Standard rvalue binding rules but with some bugs
+   #define BOOST_MOVE_MSVC_10_MEMBER_RVALUE_REF_BUG
+   #define BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG
+#elif defined(_MSC_VER) && (_MSC_VER == 1700)
+   #define BOOST_MOVE_MSVC_AUTO_MOVE_RETURN_BUG
+#endif
+
+#if defined(BOOST_MOVE_DISABLE_FORCEINLINE)
+   #define BOOST_MOVE_FORCEINLINE inline
+#elif defined(BOOST_MOVE_FORCEINLINE_IS_BOOST_FORCELINE)
+   #define BOOST_MOVE_FORCEINLINE BOOST_FORCEINLINE
+#elif defined(BOOST_MSVC) && defined(_DEBUG)
+   //"__forceinline" and MSVC seems to have some bugs in debug mode
+   #define BOOST_MOVE_FORCEINLINE inline
+#elif defined(__GNUC__) && ((__GNUC__ < 4) || (__GNUC__ == 4 && (__GNUC_MINOR__ < 5)))
+   //Older GCCs have problems with forceinline
+   #define BOOST_MOVE_FORCEINLINE inline
+#else
+   #define BOOST_MOVE_FORCEINLINE BOOST_FORCEINLINE
+#endif
+
+#endif   //#ifndef BOOST_MOVE_DETAIL_WORKAROUND_HPP

--- a/src/boost/move/iterator.hpp
+++ b/src/boost/move/iterator.hpp
@@ -1,0 +1,311 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_ITERATOR_HPP
+#define BOOST_MOVE_ITERATOR_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>  //forceinline
+#include <boost/move/detail/iterator_traits.hpp>
+#include <boost/move/utility_core.hpp>
+
+namespace boost {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! Class template move_iterator is an iterator adaptor with the same behavior
+//! as the underlying iterator except that its dereference operator implicitly
+//! converts the value returned by the underlying iterator's dereference operator
+//! to an rvalue reference. Some generic algorithms can be called with move
+//! iterators to replace copying with moving.
+template <class It>
+class move_iterator
+{
+   public:
+   typedef It                                                              iterator_type;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::value_type        value_type;
+   #if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_DOXYGEN_INVOKED)
+   typedef value_type &&                                                   reference;
+   #else
+   typedef typename ::boost::move_detail::if_
+      < ::boost::has_move_emulation_enabled<value_type>
+      , ::boost::rv<value_type>&
+      , value_type & >::type                                               reference;
+   #endif
+   typedef It                                                              pointer;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::difference_type   difference_type;
+   typedef typename boost::movelib::iterator_traits<iterator_type>::iterator_category iterator_category;
+
+   BOOST_MOVE_FORCEINLINE move_iterator()
+      : m_it()
+   {}
+
+   BOOST_MOVE_FORCEINLINE explicit move_iterator(const It &i)
+      :  m_it(i)
+   {}
+
+   template <class U>
+   BOOST_MOVE_FORCEINLINE move_iterator(const move_iterator<U>& u)
+      :  m_it(u.m_it)
+   {}
+
+   BOOST_MOVE_FORCEINLINE reference operator*() const
+   {
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+      return *m_it;
+      #else
+      return ::boost::move(*m_it);
+      #endif
+   }
+
+   BOOST_MOVE_FORCEINLINE pointer   operator->() const
+   {  return m_it;   }
+
+   BOOST_MOVE_FORCEINLINE move_iterator& operator++()
+   {  ++m_it; return *this;   }
+
+   BOOST_MOVE_FORCEINLINE move_iterator<iterator_type>  operator++(int)
+   {  move_iterator<iterator_type> tmp(*this); ++(*this); return tmp;   }
+
+   BOOST_MOVE_FORCEINLINE move_iterator& operator--()
+   {  --m_it; return *this;   }
+
+   BOOST_MOVE_FORCEINLINE move_iterator<iterator_type>  operator--(int)
+   {  move_iterator<iterator_type> tmp(*this); --(*this); return tmp;   }
+
+   move_iterator<iterator_type>  operator+ (difference_type n) const
+   {  return move_iterator<iterator_type>(m_it + n);  }
+
+   BOOST_MOVE_FORCEINLINE move_iterator& operator+=(difference_type n)
+   {  m_it += n; return *this;   }
+
+   BOOST_MOVE_FORCEINLINE move_iterator<iterator_type>  operator- (difference_type n) const
+   {  return move_iterator<iterator_type>(m_it - n);  }
+
+   BOOST_MOVE_FORCEINLINE move_iterator& operator-=(difference_type n)
+   {  m_it -= n; return *this;   }
+
+   BOOST_MOVE_FORCEINLINE reference operator[](difference_type n) const
+   {
+      #if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) || defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+      return m_it[n];
+      #else
+      return ::boost::move(m_it[n]);
+      #endif
+   }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator==(const move_iterator& x, const move_iterator& y)
+   {  return x.m_it == y.m_it;  }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator!=(const move_iterator& x, const move_iterator& y)
+   {  return x.m_it != y.m_it;  }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator< (const move_iterator& x, const move_iterator& y)
+   {  return x.m_it < y.m_it;   }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator<=(const move_iterator& x, const move_iterator& y)
+   {  return x.m_it <= y.m_it;  }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator> (const move_iterator& x, const move_iterator& y)
+   {  return x.m_it > y.m_it;  }
+
+   BOOST_MOVE_FORCEINLINE friend bool operator>=(const move_iterator& x, const move_iterator& y)
+   {  return x.m_it >= y.m_it;  }
+
+   BOOST_MOVE_FORCEINLINE friend difference_type operator-(const move_iterator& x, const move_iterator& y)
+   {  return x.m_it - y.m_it;   }
+
+   BOOST_MOVE_FORCEINLINE friend move_iterator operator+(difference_type n, const move_iterator& x)
+   {  return move_iterator(x.m_it + n);   }
+
+   private:
+   It m_it;
+};
+
+//is_move_iterator
+namespace move_detail {
+
+template <class I>
+struct is_move_iterator
+{
+   static const bool value = false;
+};
+
+template <class I>
+struct is_move_iterator< ::boost::move_iterator<I> >
+{
+   static const bool value = true;
+};
+
+}  //namespace move_detail {
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                            move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//!
+//! <b>Returns</b>: move_iterator<It>(i).
+template<class It>
+inline move_iterator<It> make_move_iterator(const It &it)
+{  return move_iterator<It>(it); }
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         back_move_insert_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+
+//! A move insert iterator that move constructs elements at the
+//! back of a container
+template <typename C> // C models Container
+class back_move_insert_iterator
+{
+   C* container_m;
+
+   public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit back_move_insert_iterator(C& x) : container_m(&x) { }
+
+   back_move_insert_iterator& operator=(reference x)
+   { container_m->push_back(boost::move(x)); return *this; }
+
+   back_move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   back_move_insert_iterator& operator*()     { return *this; }
+   back_move_insert_iterator& operator++()    { return *this; }
+   back_move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: back_move_insert_iterator<C>(x).
+template <typename C> // C models Container
+inline back_move_insert_iterator<C> back_move_inserter(C& x)
+{
+   return back_move_insert_iterator<C>(x);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         front_move_insert_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! A move insert iterator that move constructs elements int the
+//! front of a container
+template <typename C> // C models Container
+class front_move_insert_iterator
+{
+   C* container_m;
+
+public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit front_move_insert_iterator(C& x) : container_m(&x) { }
+
+   front_move_insert_iterator& operator=(reference x)
+   { container_m->push_front(boost::move(x)); return *this; }
+
+   front_move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   front_move_insert_iterator& operator*()     { return *this; }
+   front_move_insert_iterator& operator++()    { return *this; }
+   front_move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: front_move_insert_iterator<C>(x).
+template <typename C> // C models Container
+inline front_move_insert_iterator<C> front_move_inserter(C& x)
+{
+   return front_move_insert_iterator<C>(x);
+}
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//                         insert_move_iterator
+//
+//////////////////////////////////////////////////////////////////////////////
+template <typename C> // C models Container
+class move_insert_iterator
+{
+   C* container_m;
+   typename C::iterator pos_;
+
+   public:
+   typedef C                           container_type;
+   typedef typename C::value_type      value_type;
+   typedef typename C::reference       reference;
+   typedef typename C::pointer         pointer;
+   typedef typename C::difference_type difference_type;
+   typedef std::output_iterator_tag    iterator_category;
+
+   explicit move_insert_iterator(C& x, typename C::iterator pos)
+      : container_m(&x), pos_(pos)
+   {}
+
+   move_insert_iterator& operator=(reference x)
+   {
+      pos_ = container_m->insert(pos_, ::boost::move(x));
+      ++pos_;
+      return *this;
+   }
+
+   move_insert_iterator& operator=(BOOST_RV_REF(value_type) x)
+   {  reference rx = x; return this->operator=(rx);  }
+
+   move_insert_iterator& operator*()     { return *this; }
+   move_insert_iterator& operator++()    { return *this; }
+   move_insert_iterator& operator++(int) { return *this; }
+};
+
+//!
+//! <b>Returns</b>: move_insert_iterator<C>(x, it).
+template <typename C> // C models Container
+inline move_insert_iterator<C> move_inserter(C& x, typename C::iterator it)
+{
+   return move_insert_iterator<C>(x, it);
+}
+
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_ITERATOR_HPP

--- a/src/boost/move/move.hpp
+++ b/src/boost/move/move.hpp
@@ -1,0 +1,35 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright David Abrahams, Vicente Botet 2009.
+// (C) Copyright Ion Gaztanaga 2009-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+//! A general library header that includes
+//! the rest of top-level headers.
+
+#ifndef BOOST_MOVE_MOVE_HPP
+#define BOOST_MOVE_MOVE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/utility.hpp>
+#include <boost/move/iterator.hpp>
+#include <boost/move/traits.hpp>
+#include <boost/move/algorithm.hpp>
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_MOVE_HPP

--- a/src/boost/move/traits.hpp
+++ b/src/boost/move/traits.hpp
@@ -1,0 +1,77 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2009-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+
+#ifndef BOOST_MOVE_TRAITS_HPP
+#define BOOST_MOVE_TRAITS_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+
+#ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
+#include <boost/move/core.hpp>
+#endif
+#include <boost/move/detail/meta_utils.hpp>
+#include <boost/move/detail/type_traits.hpp>
+
+namespace boost {
+
+//! If this trait yields to true
+//! (<i>has_trivial_destructor_after_move &lt;T&gt;::value == true</i>)
+//! means that if T is used as argument of a move construction/assignment,
+//! there is no need to call T's destructor.
+//! This optimization tipically is used to improve containers' performance.
+//!
+//! By default this trait is true if the type has trivial destructor,
+//! every class should specialize this trait if it wants to improve performance
+//! when inserted in containers.
+template <class T>
+struct has_trivial_destructor_after_move
+   : ::boost::move_detail::is_trivially_destructible<T>
+{};
+
+//! By default this traits returns
+//! <pre>boost::is_nothrow_move_constructible<T>::value && boost::is_nothrow_move_assignable<T>::value </pre>.
+//! Classes with non-throwing move constructor
+//! and assignment can specialize this trait to obtain some performance improvements.
+template <class T>
+struct has_nothrow_move
+{
+   static const bool value = boost::move_detail::is_nothrow_move_constructible<T>::value &&
+                             boost::move_detail::is_nothrow_move_assignable<T>::value;
+};
+
+namespace move_detail {
+
+template <class T>
+struct is_nothrow_move_constructible_or_uncopyable
+{
+   //The standard requires is_nothrow_move_constructible for move_if_noexcept
+   //but a user (usually in C++03) might specialize has_nothrow_move which includes it
+   static const bool value = is_nothrow_move_constructible<T>::value ||
+                             has_nothrow_move<T>::value ||
+                            !is_copy_constructible<T>::value;
+};
+
+}  //move_detail {
+}  //namespace boost {
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_TRAITS_HPP

--- a/src/boost/move/utility.hpp
+++ b/src/boost/move/utility.hpp
@@ -1,0 +1,150 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+//! This header includes core utilities from <tt><boost/move/utility_core.hpp></tt> and defines
+//! some more advanced utilities such as:
+
+#ifndef BOOST_MOVE_MOVE_UTILITY_HPP
+#define BOOST_MOVE_MOVE_UTILITY_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>  //forceinline
+#include <boost/move/utility_core.hpp>
+#include <boost/move/traits.hpp>
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   namespace boost {
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                            move_if_noexcept()
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < enable_move_utility_emulation<T>::value && !has_move_emulation_enabled<T>::value
+      , typename ::boost::move_detail::add_const<T>::type &
+      >::type
+         move_if_noexcept(T& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < enable_move_utility_emulation<T>::value && has_move_emulation_enabled<T>::value
+            && ::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value, rv<T>&>::type
+         move_if_noexcept(T& x) BOOST_NOEXCEPT
+   {
+      return *static_cast<rv<T>* >(::boost::move_detail::addressof(x));
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < enable_move_utility_emulation<T>::value && has_move_emulation_enabled<T>::value
+            && ::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value
+      , rv<T>&
+      >::type
+         move_if_noexcept(rv<T>& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < enable_move_utility_emulation<T>::value && has_move_emulation_enabled<T>::value
+            && !::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value
+      , typename ::boost::move_detail::add_const<T>::type &
+      >::type
+         move_if_noexcept(T& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+      < enable_move_utility_emulation<T>::value && has_move_emulation_enabled<T>::value
+            && !::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value
+      , typename ::boost::move_detail::add_const<T>::type &
+      >::type
+         move_if_noexcept(rv<T>& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   }  //namespace boost
+
+#else    //#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   #if defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+      #include <utility>
+
+      namespace boost{
+
+      using ::std::move_if_noexcept;
+
+      }  //namespace boost
+
+   #else //!BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE
+
+      namespace boost {
+
+      //////////////////////////////////////////////////////////////////////////////
+      //
+      //                            move_if_noexcept()
+      //
+      //////////////////////////////////////////////////////////////////////////////
+      #if defined(BOOST_MOVE_DOXYGEN_INVOKED)
+         //! This function provides a way to convert a reference into a rvalue reference
+         //! in compilers with rvalue references. For other compilers converts T & into
+         //! <i>::boost::rv<T> &</i> so that move emulation is activated. Reference
+         //! would be converted to rvalue reference only if input type is nothrow move
+         //! constructible or if it has no copy constructor. In all other cases const
+         //! reference would be returned
+         template <class T>
+         rvalue_reference_or_const_lvalue_reference move_if_noexcept(input_reference) noexcept;
+
+      #else //BOOST_MOVE_DOXYGEN_INVOKED
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+            < ::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value, T&&>::type
+               move_if_noexcept(T& x) BOOST_NOEXCEPT
+         {  return ::boost::move(x);   }
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_c
+            < !::boost::move_detail::is_nothrow_move_constructible_or_uncopyable<T>::value, const T&>::type
+               move_if_noexcept(T& x) BOOST_NOEXCEPT
+         {  return x;  }
+
+      #endif //BOOST_MOVE_DOXYGEN_INVOKED
+
+      }  //namespace boost {
+
+   #endif   //#if defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+#endif   //BOOST_NO_CXX11_RVALUE_REFERENCES
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_MOVE_UTILITY_HPP

--- a/src/boost/move/utility_core.hpp
+++ b/src/boost/move/utility_core.hpp
@@ -1,0 +1,318 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// (C) Copyright Ion Gaztanaga 2012-2012.
+// Distributed under the Boost Software License, Version 1.0.
+// (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// See http://www.boost.org/libs/move for documentation.
+//
+//////////////////////////////////////////////////////////////////////////////
+
+//! \file
+//! This header defines core utilities to ease the development
+//! of move-aware functions. This header minimizes dependencies
+//! from other libraries.
+
+#ifndef BOOST_MOVE_MOVE_UTILITY_CORE_HPP
+#define BOOST_MOVE_MOVE_UTILITY_CORE_HPP
+
+#ifndef BOOST_CONFIG_HPP
+#  include <boost/config.hpp>
+#endif
+#
+#if defined(BOOST_HAS_PRAGMA_ONCE)
+#  pragma once
+#endif
+
+#include <boost/move/detail/config_begin.hpp>
+#include <boost/move/detail/workaround.hpp>  //forceinline
+#include <boost/move/core.hpp>
+#include <boost/move/detail/meta_utils.hpp>
+#include <boost/static_assert.hpp>
+
+#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   namespace boost {
+
+   template<class T>
+   struct enable_move_utility_emulation
+   {
+      static const bool value = true;
+   };
+    
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                            move()
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < T &
+      , enable_move_utility_emulation<T>
+      , has_move_emulation_disabled<T>
+      >::type
+         move(T& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < rv<T>&
+      , enable_move_utility_emulation<T>
+      , has_move_emulation_enabled<T>
+      >::type
+         move(T& x) BOOST_NOEXCEPT
+   {
+      return *BOOST_MOVE_TO_RV_CAST(::boost::rv<T>*, ::boost::move_detail::addressof(x) );
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < rv<T>&
+      , enable_move_utility_emulation<T>
+      , has_move_emulation_enabled<T>
+      >::type
+         move(rv<T>& x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                            forward()
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < T &
+      , enable_move_utility_emulation<T>
+      , ::boost::move_detail::is_rv<T>
+      >::type
+         forward(const typename ::boost::move_detail::identity<T>::type &x) BOOST_NOEXCEPT
+   {
+      return const_cast<T&>(x);
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < const T &
+      , enable_move_utility_emulation<T>
+      , ::boost::move_detail::is_not_rv<T>
+      >::type
+         forward(const typename ::boost::move_detail::identity<T>::type &x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   //////////////////////////////////////////////////////////////////////////////
+   //
+   //                        move_if_not_lvalue_reference()
+   //
+   //////////////////////////////////////////////////////////////////////////////
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < T &
+      , enable_move_utility_emulation<T>
+      , ::boost::move_detail::is_rv<T>
+      >::type
+         move_if_not_lvalue_reference(const typename ::boost::move_detail::identity<T>::type &x) BOOST_NOEXCEPT
+   {
+      return const_cast<T&>(x);
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < typename ::boost::move_detail::add_lvalue_reference<T>::type
+      , enable_move_utility_emulation<T>
+      , ::boost::move_detail::is_not_rv<T>
+      , ::boost::move_detail::or_
+         < ::boost::move_detail::is_lvalue_reference<T>
+         , has_move_emulation_disabled<T>
+         >
+      >::type
+         move_if_not_lvalue_reference(typename ::boost::move_detail::remove_reference<T>::type &x) BOOST_NOEXCEPT
+   {
+      return x;
+   }
+
+   template <class T>
+   BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::enable_if_and
+      < rv<T>&
+      , enable_move_utility_emulation<T>
+      , ::boost::move_detail::is_not_rv<T>
+      , ::boost::move_detail::and_
+         < ::boost::move_detail::not_< ::boost::move_detail::is_lvalue_reference<T> >
+         , has_move_emulation_enabled<T>
+         >
+      >::type
+         move_if_not_lvalue_reference(typename ::boost::move_detail::remove_reference<T>::type &x) BOOST_NOEXCEPT
+   {
+      return move(x);
+   }
+
+   }  //namespace boost
+
+#else    //#if defined(BOOST_NO_CXX11_RVALUE_REFERENCES) && !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+   #if defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+      #include <utility>
+
+      namespace boost{
+
+      using ::std::move;
+      using ::std::forward;
+
+      }  //namespace boost
+
+   #else //!BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE
+
+      namespace boost {
+
+      //! This trait's internal boolean `value` is false in compilers with rvalue references
+      //! and true in compilers without rvalue references.
+      //!
+      //! A user can specialize this trait for a type T to false to SFINAE out `move` and `forward`
+      //! so that the user can define a different move emulation for that type in namespace boost
+      //! (e.g. another Boost library for its types) and avoid any overload ambiguity.
+      template<class T>
+      struct enable_move_utility_emulation
+      {
+         static const bool value = false;
+      };
+
+      //////////////////////////////////////////////////////////////////////////////
+      //
+      //                                  move
+      //
+      //////////////////////////////////////////////////////////////////////////////
+
+      #if defined(BOOST_MOVE_DOXYGEN_INVOKED)
+         //! This function provides a way to convert a reference into a rvalue reference
+         //! in compilers with rvalue references. For other compilers if `T` is Boost.Move
+         //! enabled type then it converts `T&` into <tt>::boost::rv<T> &</tt> so that
+         //! move emulation is activated, else it returns `T &`.
+         template <class T>
+         rvalue_reference move(input_reference) noexcept;
+
+      #elif defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+
+         //Old move approach, lvalues could bind to rvalue references
+         template <class T>
+         BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::remove_reference<T>::type && move(T&& t) BOOST_NOEXCEPT
+         {  return t;   }
+
+      #else //BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE typename ::boost::move_detail::remove_reference<T>::type && move(T&& t) BOOST_NOEXCEPT
+         { return static_cast<typename ::boost::move_detail::remove_reference<T>::type &&>(t); }
+
+      #endif   //BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES
+
+      //////////////////////////////////////////////////////////////////////////////
+      //
+      //                                  forward
+      //
+      //////////////////////////////////////////////////////////////////////////////
+
+
+      #if defined(BOOST_MOVE_DOXYGEN_INVOKED)
+         //! This function provides limited form of forwarding that is usually enough for
+         //! in-place construction and avoids the exponential overloading for
+         //! achieve the limited forwarding in C++03.
+         //!
+         //! For compilers with rvalue references this function provides perfect forwarding.
+         //!
+         //! Otherwise:
+         //! * If input_reference binds to const ::boost::rv<T> & then it output_reference is
+         //!   ::boost::rv<T> &
+         //!
+         //! * Else, output_reference is equal to input_reference.
+         template <class T> output_reference forward(input_reference) noexcept;
+      #elif defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+
+         //Old move approach, lvalues could bind to rvalue references
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& forward(typename ::boost::move_detail::identity<T>::type&& t) BOOST_NOEXCEPT
+         {  return t;   }
+
+      #else //Old move
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& forward(typename ::boost::move_detail::remove_reference<T>::type& t) BOOST_NOEXCEPT
+         {  return static_cast<T&&>(t);   }
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& forward(typename ::boost::move_detail::remove_reference<T>::type&& t) BOOST_NOEXCEPT
+         {
+            //"boost::forward<T> error: 'T' is a lvalue reference, can't forward as rvalue.";
+            BOOST_STATIC_ASSERT(!boost::move_detail::is_lvalue_reference<T>::value);
+            return static_cast<T&&>(t);
+         }
+
+      #endif   //BOOST_MOVE_DOXYGEN_INVOKED
+
+      //////////////////////////////////////////////////////////////////////////////
+      //
+      //                         move_if_not_lvalue_reference
+      //
+      //////////////////////////////////////////////////////////////////////////////
+
+
+      #if defined(BOOST_MOVE_DOXYGEN_INVOKED)
+         //! <b>Effects</b>: Calls `boost::move` if `input_reference` is not a lvalue reference.
+         //!   Otherwise returns the reference
+         template <class T> output_reference move_if_not_lvalue_reference(input_reference) noexcept;
+      #elif defined(BOOST_MOVE_OLD_RVALUE_REF_BINDING_RULES)
+
+         //Old move approach, lvalues could bind to rvalue references
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& move_if_not_lvalue_reference(typename ::boost::move_detail::identity<T>::type&& t) BOOST_NOEXCEPT
+         {  return t;   }
+
+      #else //Old move
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& move_if_not_lvalue_reference(typename ::boost::move_detail::remove_reference<T>::type& t) BOOST_NOEXCEPT
+         {  return static_cast<T&&>(t);   }
+
+         template <class T>
+         BOOST_MOVE_FORCEINLINE T&& move_if_not_lvalue_reference(typename ::boost::move_detail::remove_reference<T>::type&& t) BOOST_NOEXCEPT
+         {
+            //"boost::forward<T> error: 'T' is a lvalue reference, can't forward as rvalue.";
+            BOOST_STATIC_ASSERT(!boost::move_detail::is_lvalue_reference<T>::value);
+            return static_cast<T&&>(t);
+         }
+
+      #endif   //BOOST_MOVE_DOXYGEN_INVOKED
+
+      }  //namespace boost {
+
+   #endif   //#if defined(BOOST_MOVE_USE_STANDARD_LIBRARY_MOVE)
+
+#endif   //BOOST_NO_CXX11_RVALUE_REFERENCES
+
+#if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+namespace boost{
+namespace move_detail{
+
+template <typename T>
+typename boost::move_detail::add_rvalue_reference<T>::type declval();
+
+}  //namespace move_detail{
+}  //namespace boost{
+
+#endif   //#if !defined(BOOST_MOVE_DOXYGEN_INVOKED)
+
+
+#include <boost/move/detail/config_end.hpp>
+
+#endif //#ifndef BOOST_MOVE_MOVE_UTILITY_CORE_HPP

--- a/src/boost/static_assert.hpp
+++ b/src/boost/static_assert.hpp
@@ -1,0 +1,180 @@
+//  (C) Copyright John Maddock 2000.
+//  Use, modification and distribution are subject to the 
+//  Boost Software License, Version 1.0. (See accompanying file 
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  See http://www.boost.org/libs/static_assert for documentation.
+
+/*
+ Revision history:
+   02 August 2000
+      Initial version.
+*/
+
+#ifndef BOOST_STATIC_ASSERT_HPP
+#define BOOST_STATIC_ASSERT_HPP
+
+#include <boost/config.hpp>
+#include <boost/detail/workaround.hpp>
+
+#if defined(__GNUC__) && !defined(__GXX_EXPERIMENTAL_CXX0X__)
+//
+// This is horrible, but it seems to be the only we can shut up the
+// "anonymous variadic macros were introduced in C99 [-Wvariadic-macros]"
+// warning that get spewed out otherwise in non-C++11 mode.
+//
+#pragma GCC system_header
+#endif
+
+#ifndef BOOST_NO_CXX11_STATIC_ASSERT
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#     define BOOST_STATIC_ASSERT_MSG( ... ) static_assert(__VA_ARGS__)
+#  else
+#     define BOOST_STATIC_ASSERT_MSG( B, Msg ) static_assert( B, Msg )
+#  endif
+#else
+#     define BOOST_STATIC_ASSERT_MSG( B, Msg ) BOOST_STATIC_ASSERT( B )
+#endif
+
+#ifdef __BORLANDC__
+//
+// workaround for buggy integral-constant expression support:
+#define BOOST_BUGGY_INTEGRAL_CONSTANT_EXPRESSIONS
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ == 3) && ((__GNUC_MINOR__ == 3) || (__GNUC_MINOR__ == 4))
+// gcc 3.3 and 3.4 don't produce good error messages with the default version:
+#  define BOOST_SA_GCC_WORKAROUND
+#endif
+
+//
+// If the compiler issues warnings about old C style casts,
+// then enable this:
+//
+#if defined(__GNUC__) && ((__GNUC__ > 3) || ((__GNUC__ == 3) && (__GNUC_MINOR__ >= 4)))
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#     define BOOST_STATIC_ASSERT_BOOL_CAST( ... ) ((__VA_ARGS__) == 0 ? false : true)
+#  else
+#     define BOOST_STATIC_ASSERT_BOOL_CAST( x ) ((x) == 0 ? false : true)
+#  endif
+#else
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#     define BOOST_STATIC_ASSERT_BOOL_CAST( ... ) (bool)(__VA_ARGS__)
+#  else
+#     define BOOST_STATIC_ASSERT_BOOL_CAST(x) (bool)(x)
+#  endif
+#endif
+
+#ifndef BOOST_NO_CXX11_STATIC_ASSERT
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#     define BOOST_STATIC_ASSERT( ... ) static_assert(__VA_ARGS__, #__VA_ARGS__)
+#  else
+#     define BOOST_STATIC_ASSERT( B ) static_assert(B, #B)
+#  endif
+#else
+
+namespace boost{
+
+// HP aCC cannot deal with missing names for template value parameters
+template <bool x> struct STATIC_ASSERTION_FAILURE;
+
+template <> struct STATIC_ASSERTION_FAILURE<true> { enum { value = 1 }; };
+
+// HP aCC cannot deal with missing names for template value parameters
+template<int x> struct static_assert_test{};
+
+}
+
+//
+// Implicit instantiation requires that all member declarations be
+// instantiated, but that the definitions are *not* instantiated.
+//
+// It's not particularly clear how this applies to enum's or typedefs;
+// both are described as declarations [7.1.3] and [7.2] in the standard,
+// however some compilers use "delayed evaluation" of one or more of
+// these when implicitly instantiating templates.  We use typedef declarations
+// by default, but try defining BOOST_USE_ENUM_STATIC_ASSERT if the enum
+// version gets better results from your compiler...
+//
+// Implementation:
+// Both of these versions rely on sizeof(incomplete_type) generating an error
+// message containing the name of the incomplete type.  We use
+// "STATIC_ASSERTION_FAILURE" as the type name here to generate
+// an eye catching error message.  The result of the sizeof expression is either
+// used as an enum initialiser, or as a template argument depending which version
+// is in use...
+// Note that the argument to the assert is explicitly cast to bool using old-
+// style casts: too many compilers currently have problems with static_cast
+// when used inside integral constant expressions.
+//
+#if !defined(BOOST_BUGGY_INTEGRAL_CONSTANT_EXPRESSIONS)
+
+#if defined(BOOST_MSVC) && defined(BOOST_NO_CXX11_VARIADIC_MACROS)
+#define BOOST_STATIC_ASSERT( B ) \
+   typedef ::boost::static_assert_test<\
+      sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST ( B ) >)>\
+         BOOST_JOIN(boost_static_assert_typedef_, __COUNTER__)
+#elif defined(BOOST_MSVC)
+#define BOOST_STATIC_ASSERT(...) \
+   typedef ::boost::static_assert_test<\
+      sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST (__VA_ARGS__) >)>\
+         BOOST_JOIN(boost_static_assert_typedef_, __COUNTER__)
+#elif (defined(BOOST_INTEL_CXX_VERSION) || defined(BOOST_SA_GCC_WORKAROUND))  && defined(BOOST_NO_CXX11_VARIADIC_MACROS)
+// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error 
+// instead of warning in case of failure
+# define BOOST_STATIC_ASSERT( B ) \
+    typedef char BOOST_JOIN(boost_static_assert_typedef_, __LINE__) \
+        [ ::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( B ) >::value ]
+#elif (defined(BOOST_INTEL_CXX_VERSION) || defined(BOOST_SA_GCC_WORKAROUND))  && !defined(BOOST_NO_CXX11_VARIADIC_MACROS)
+// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error 
+// instead of warning in case of failure
+# define BOOST_STATIC_ASSERT(...) \
+    typedef char BOOST_JOIN(boost_static_assert_typedef_, __LINE__) \
+        [ ::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( __VA_ARGS__ ) >::value ]
+#elif defined(__sgi)
+// special version for SGI MIPSpro compiler
+#define BOOST_STATIC_ASSERT( B ) \
+   BOOST_STATIC_CONSTANT(bool, \
+     BOOST_JOIN(boost_static_assert_test_, __LINE__) = ( B )); \
+   typedef ::boost::static_assert_test<\
+     sizeof(::boost::STATIC_ASSERTION_FAILURE< \
+       BOOST_JOIN(boost_static_assert_test_, __LINE__) >)>\
+         BOOST_JOIN(boost_static_assert_typedef_, __LINE__)
+#elif BOOST_WORKAROUND(__MWERKS__, <= 0x3003)
+// special version for CodeWarrior <= 8.x
+#define BOOST_STATIC_ASSERT( B ) \
+   BOOST_STATIC_CONSTANT(int, \
+     BOOST_JOIN(boost_static_assert_test_, __LINE__) = \
+       sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( B ) >) )
+#else
+// generic version
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#     define BOOST_STATIC_ASSERT( ... ) \
+         typedef ::boost::static_assert_test<\
+            sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( __VA_ARGS__ ) >)>\
+               BOOST_JOIN(boost_static_assert_typedef_, __LINE__) BOOST_ATTRIBUTE_UNUSED
+#  else
+#     define BOOST_STATIC_ASSERT( B ) \
+         typedef ::boost::static_assert_test<\
+            sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( B ) >)>\
+               BOOST_JOIN(boost_static_assert_typedef_, __LINE__) BOOST_ATTRIBUTE_UNUSED
+#  endif
+#endif
+
+#else
+// alternative enum based implementation:
+#  ifndef BOOST_NO_CXX11_VARIADIC_MACROS
+#    define BOOST_STATIC_ASSERT( ... ) \
+         enum { BOOST_JOIN(boost_static_assert_enum_, __LINE__) \
+            = sizeof(::boost::STATIC_ASSERTION_FAILURE< (bool)( __VA_ARGS__ ) >) }
+#  else
+#    define BOOST_STATIC_ASSERT(B) \
+         enum { BOOST_JOIN(boost_static_assert_enum_, __LINE__) \
+            = sizeof(::boost::STATIC_ASSERTION_FAILURE< (bool)( B ) >) }
+#  endif
+#endif
+#endif // defined(BOOST_NO_CXX11_STATIC_ASSERT)
+
+#endif // BOOST_STATIC_ASSERT_HPP
+
+

--- a/src/boost/throw_exception.hpp
+++ b/src/boost/throw_exception.hpp
@@ -1,0 +1,102 @@
+#ifndef UUID_AA15E74A856F11E08B8D93F24824019B
+#define UUID_AA15E74A856F11E08B8D93F24824019B
+#if (__GNUC__*100+__GNUC_MINOR__>301) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma GCC system_header
+#endif
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(push,1)
+#endif
+
+// MS compatible compilers support #pragma once
+
+#if defined(_MSC_VER) && (_MSC_VER >= 1020)
+# pragma once
+#endif
+
+//
+//  boost/throw_exception.hpp
+//
+//  Copyright (c) 2002 Peter Dimov and Multi Media Ltd.
+//  Copyright (c) 2008-2009 Emil Dotchevski and Reverge Studios, Inc.
+//
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+//
+//  http://www.boost.org/libs/utility/throw_exception.html
+//
+
+#include <boost/detail/workaround.hpp>
+#include <boost/config.hpp>
+#include <exception>
+
+#if !defined( BOOST_EXCEPTION_DISABLE ) && defined( __BORLANDC__ ) && BOOST_WORKAROUND( __BORLANDC__, BOOST_TESTED_AT(0x593) )
+# define BOOST_EXCEPTION_DISABLE
+#endif
+
+#if !defined( BOOST_EXCEPTION_DISABLE ) && defined( BOOST_MSVC ) && BOOST_WORKAROUND( BOOST_MSVC, < 1310 )
+# define BOOST_EXCEPTION_DISABLE
+#endif
+
+#if !defined( BOOST_EXCEPTION_DISABLE )
+# include <boost/exception/exception.hpp>
+#if !defined(BOOST_THROW_EXCEPTION_CURRENT_FUNCTION)
+# include <boost/current_function.hpp>
+# define BOOST_THROW_EXCEPTION_CURRENT_FUNCTION BOOST_CURRENT_FUNCTION
+#endif
+# define BOOST_THROW_EXCEPTION(x) ::boost::exception_detail::throw_exception_(x,BOOST_THROW_EXCEPTION_CURRENT_FUNCTION,__FILE__,__LINE__)
+#else
+# define BOOST_THROW_EXCEPTION(x) ::boost::throw_exception(x)
+#endif
+
+namespace boost
+{
+#ifdef BOOST_NO_EXCEPTIONS
+
+void throw_exception( std::exception const & e ); // user defined
+
+#else
+
+inline void throw_exception_assert_compatibility( std::exception const & ) { }
+
+template<class E> BOOST_NORETURN inline void throw_exception( E const & e )
+{
+    //All boost exceptions are required to derive from std::exception,
+    //to ensure compatibility with BOOST_NO_EXCEPTIONS.
+    throw_exception_assert_compatibility(e);
+
+#ifndef BOOST_EXCEPTION_DISABLE
+    throw enable_current_exception(enable_error_info(e));
+#else
+    throw e;
+#endif
+}
+
+#endif
+
+#if !defined( BOOST_EXCEPTION_DISABLE )
+    namespace
+    exception_detail
+    {
+        template <class E>
+        BOOST_NORETURN
+        void
+        throw_exception_( E const & x, char const * current_function, char const * file, int line )
+        {
+            boost::throw_exception(
+                set_info(
+                    set_info(
+                        set_info(
+                            enable_error_info(x),
+                            throw_function(current_function)),
+                        throw_file(file)),
+                    throw_line(line)));
+        }
+    }
+#endif
+} // namespace boost
+
+#if defined(_MSC_VER) && !defined(BOOST_EXCEPTION_ENABLE_WARNINGS)
+#pragma warning(pop)
+#endif
+#endif

--- a/src/boost/utility/addressof.hpp
+++ b/src/boost/utility/addressof.hpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2014 Glen Fernandes
+ *
+ * Distributed under the Boost Software License, Version 1.0. (See
+ * accompanying file LICENSE_1_0.txt or copy at
+ * http://www.boost.org/LICENSE_1_0.txt)
+ */
+
+#ifndef BOOST_UTILITY_ADDRESSOF_HPP
+#define BOOST_UTILITY_ADDRESSOF_HPP
+
+// The header file at this path is deprecated;
+// use boost/core/addressof.hpp instead.
+
+#include <boost/core/addressof.hpp>
+
+#endif


### PR DESCRIPTION
This branch adds in the remaining necessary boost headers to compile on MacOS & Linux, and fixes one issue in the Makefile. 

I've tested this on MacOS 10.13.5 and Ubuntu 18.04 and it appears to work on both platforms. 